### PR TITLE
added Dutch translations

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -12,7 +12,8 @@
   },
   "description": {
     "en": "Sustainable future through eco-smart technology.",
-    "no": "Bærekraftig fremtid gjennom øko-smart teknologi."
+    "no": "Bærekraftig fremtid gjennom øko-smart teknologi.",
+    "nl": "Duurzame toekomst door eco-smart technologie."
   },
   "category": [
     "energy"
@@ -37,6 +38,16 @@
       "lading",
       "elbil",
       "solcelle"
+    ],
+    "en": [
+      "energie",
+      "vermogen",
+      "myenergi",
+      "zappi",
+      "harvi",
+      "laden",
+      "EV",
+      "zonnepanelen"
     ]
   },
   "permissions": [],

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -39,7 +39,7 @@
       "elbil",
       "solcelle"
     ],
-    "en": [
+    "nl": [
       "energie",
       "vermogen",
       "myenergi",

--- a/.homeycompose/capabilities/charge_mode.json
+++ b/.homeycompose/capabilities/charge_mode.json
@@ -2,7 +2,8 @@
     "type": "enum",
     "title": {
         "en": "Charge Mode",
-        "no": "Lademodus"
+        "no": "Lademodus",
+        "nl": "Laadmodus"
     },
     "getable": true,
     "setable": false,
@@ -13,28 +14,32 @@
             "id": "1",
             "title": {
                 "en": "Fast",
-                "no": "Rask"
+                "no": "Rask",
+                "nl": "Snel"
             }
         },
         {
             "id": "2",
             "title": {
                 "en": "Eco",
-                "no": "Eco"
+                "no": "Eco",
+                "nl": "Eco"
             }
         },
         {
             "id": "3",
             "title": {
                 "en": "Eco+",
-                "no": "Eco+"
+                "no": "Eco+",
+                "nl": "Eco+"
             }
         },
         {
             "id": "4",
             "title": {
                 "en": "Off",
-                "no": "Av"
+                "no": "Av",
+                "nl": "Uit"
             }
         }
     ]

--- a/.homeycompose/capabilities/charge_mode_selector.json
+++ b/.homeycompose/capabilities/charge_mode_selector.json
@@ -2,7 +2,8 @@
     "type": "enum",
     "title": {
         "en": "Charge Mode",
-        "no": "Lademodus"
+        "no": "Lademodus",
+        "nl": "Laadmodus"
     },
     "getable": true,
     "setable": true,
@@ -13,28 +14,32 @@
             "id": "1",
             "title": {
                 "en": "Fast",
-                "no": "Rask"
+                "no": "Rask",
+                "nl": "Snel"
             }
         },
         {
             "id": "2",
             "title": {
                 "en": "Eco",
-                "no": "Eco"
+                "no": "Eco",
+                "nl": "Eco"
             }
         },
         {
             "id": "3",
             "title": {
                 "en": "Eco+",
-                "no": "Eco+"
+                "no": "Eco+",
+                "nl": "Eco+"
             }
         },
         {
             "id": "4",
             "title": {
                 "en": "Off",
-                "no": "Av"
+                "no": "Av",
+                "nl": "Uit"
             }
         }
     ]

--- a/.homeycompose/capabilities/charge_session_consumption.json
+++ b/.homeycompose/capabilities/charge_session_consumption.json
@@ -2,7 +2,8 @@
     "type": "number",
     "title": {
         "en": "Charge added last session",
-        "no": "Siste lading"
+        "no": "Siste lading",
+        "nl": "Lading toegevoegd in laatste sessie"
     },
     "getable": true,
     "setable": false,

--- a/.homeycompose/capabilities/charger_status.json
+++ b/.homeycompose/capabilities/charger_status.json
@@ -2,7 +2,8 @@
     "type": "enum",
     "title": {
         "en": "Charger Status",
-        "no": "Ladestatus"
+        "no": "Ladestatus",
+        "nl": "Laderstatus"
     },
     "getable": true,
     "setable": false,
@@ -13,42 +14,48 @@
             "id": "A",
             "title": {
                 "en": "EV Disconnected",
-                "no": "Bil Frakoblet"
+                "no": "Bil Frakoblet",
+                "nl": "EV losgekoppeld"
             }
         },
         {
             "id": "B1",
             "title": {
                 "en": "EV Connected",
-                "no": "Bil Tilkoblet"
+                "no": "Bil Tilkoblet",
+                "nl": "EV verbonden"
             }
         },
         {
             "id": "B2",
             "title": {
                 "en": "Waiting for EV",
-                "no": "Venter på Bil"
+                "no": "Venter på Bil",
+                "nl": "Wachten op EV"
             }
         },
         {
             "id": "C1",
             "title": {
                 "en": "EV ready to charge",
-                "no": "Bil klar for lading"
+                "no": "Bil klar for lading",
+                "nl": "EV gereed om te laden"
             }
         },
         {
             "id": "C2",
             "title": {
                 "en": "Charging",
-                "no": "Lader"
+                "no": "Lader",
+                "nl": "Laden"
             }
         },
         {
             "id": "F",
             "title": {
                 "en": "Fault",
-                "no": "Feil"
+                "no": "Feil",
+                "nl": "Fout"
             }
         }
     ]

--- a/.homeycompose/capabilities/heater_1_name.json
+++ b/.homeycompose/capabilities/heater_1_name.json
@@ -2,7 +2,7 @@
     "title": {
         "en": "Heater 1",
         "no": "Varmeelement 1",
-        "nl": "Verwarmingselement"
+        "nl": "Verwarmingselement 1"
     },
     "type": "string",
     "getable": true,
@@ -10,14 +10,14 @@
     "uiComponent": "media",
     "$flow": {
         "triggers": [
-        {
-            "id": "heater_name_changed",
-            "title": {
-                "en": "The name changed",
-                "no": "Navnet ble endret",
-                "nl": "De naam is gewijzigd"
+            {
+                "id": "heater_name_changed",
+                "title": {
+                    "en": "The name changed",
+                    "no": "Navnet ble endret",
+                    "nl": "De naam is gewijzigd"
                 }
             }
         ]
     }
-  }
+}

--- a/.homeycompose/capabilities/heater_1_name.json
+++ b/.homeycompose/capabilities/heater_1_name.json
@@ -1,21 +1,23 @@
 {
     "title": {
-      "en": "Heater 1",
-      "no": "Varmeelement 1"
+        "en": "Heater 1",
+        "no": "Varmeelement 1",
+        "nl": "Verwarmingselement"
     },
     "type": "string",
     "getable": true,
     "setable": false,
     "uiComponent": "media",
     "$flow": {
-      "triggers": [
+        "triggers": [
         {
-          "id": "heater_name_changed",
-          "title": {
-            "en": "The name changed",
-            "no": "Navnet ble endret"
-          }
-        }
-      ]
+            "id": "heater_name_changed",
+            "title": {
+                "en": "The name changed",
+                "no": "Navnet ble endret",
+                "nl": "De naam is gewijzigd"
+                }
+            }
+        ]
     }
   }

--- a/.homeycompose/capabilities/heater_1_name.json
+++ b/.homeycompose/capabilities/heater_1_name.json
@@ -15,7 +15,7 @@
                 "title": {
                     "en": "The name changed",
                     "no": "Navnet ble endret",
-                    "nl": "De naam is gewijzigd"
+                    "nl": "De naam is veranderd"
                 }
             }
         ]

--- a/.homeycompose/capabilities/heater_2_name.json
+++ b/.homeycompose/capabilities/heater_2_name.json
@@ -1,21 +1,23 @@
 {
     "title": {
-      "en": "Heater 2",
-      "no": "Varmeelement 2"
+        "en": "Heater 2",
+        "no": "Varmeelement 2",
+        "nl": "Verwarmingselement 2"
     },
     "type": "string",
     "getable": true,
     "setable": false,
     "uiComponent": "media",
     "$flow": {
-      "triggers": [
-        {
-          "id": "heater_name_changed",
-          "title": {
-            "en": "The name changed",
-            "no": "Navnet ble endret"
-          }
-        }
-      ]
+        "triggers": [
+            {
+                "id": "heater_name_changed",
+                "title": {
+                    "en": "The name changed",
+                    "no": "Navnet ble endret",
+                    "nl": "De naam is veranderd"
+                }
+            }
+        ]
     }
-  }
+}

--- a/.homeycompose/capabilities/heater_session_transferred.json
+++ b/.homeycompose/capabilities/heater_session_transferred.json
@@ -2,7 +2,8 @@
     "type": "number",
     "title": {
         "en": "Transferred last session",
-        "no": "Overført siste økt"
+        "no": "Overført siste økt",
+        "nl": "Omgeleid in laatste sessie"
     },
     "getable": true,
     "setable": false,

--- a/.homeycompose/capabilities/heater_status.json
+++ b/.homeycompose/capabilities/heater_status.json
@@ -15,7 +15,7 @@
             "title": {
                 "en": "Paused",
                 "no": "Pauset",
-                "nl": "Gepauzeerd'
+                "nl": "Gepauzeerd"
             }
         },
         {

--- a/.homeycompose/capabilities/heater_status.json
+++ b/.homeycompose/capabilities/heater_status.json
@@ -2,7 +2,8 @@
     "type": "enum",
     "title": {
         "en": "Heater Status",
-        "no": "Varmerstatus"
+        "no": "Varmerstatus",
+        "nl": "Verwarming status"
     },
     "getable": true,
     "setable": false,
@@ -13,21 +14,24 @@
             "id": "1",
             "title": {
                 "en": "Paused",
-                "no": "Pauset"
+                "no": "Pauset",
+                "nl": "Gepauzeerd'
             }
         },
         {
             "id": "2",
             "title": {
                 "en": "Unknown",
-                "no": "Ukjent"
+                "no": "Ukjent",
+                "nl": "Onbekend"
             }
         },
         {
             "id": "3",
             "title": {
                 "en": "Diverting",
-                "no": "Omdirigerer"
+                "no": "Omdirigerer",
+                "nl": "Omleiden"
             }
         },
         {
@@ -40,14 +44,16 @@
             "id": "5",
             "title": {
                 "en": "Max Temp Reached",
-                "no": "Max Temp Oppnådd"
+                "no": "Max Temp Oppnådd",
+                "nl": "Max Temp Bereikt"
             }
         },
         {
             "id": "6",
             "title": {
                 "en": "Stopped",
-                "no": "Stoppet"
+                "no": "Stoppet",
+                "nl": "Gestopt"
             }
         }
     ]

--- a/.homeycompose/capabilities/measure_power_generated.json
+++ b/.homeycompose/capabilities/measure_power_generated.json
@@ -2,7 +2,8 @@
     "type": "number",
     "title": {
         "en": "Power generated",
-        "no": "Generert kraft"
+        "no": "Generert kraft",
+        "nl": "Opgewekt vermogen"
     },
     "getable": true,
     "setable": false,

--- a/README.nl.txt
+++ b/README.nl.txt
@@ -1,0 +1,7 @@
+Verbind je Zappi EV lader, je Harvi energie sensor en/of je Eddi energie-omleider met Homey. Met grafieken, 'Insights', en kaarten om flows mee te maken.
+
+Start en stop het laden van je EV handmatig, met een schema, of volgens de voorwaarden/condities uit flows. Via bijv. Tbber kan je prijsgestuurd laden.
+
+Bedien je warmwater of ander verwarming met Eddi energie-omleider. Of stel in om je zonnepanelen te gebruiken voor warmwater of om je EV te laden.
+
+Monitor stroom en energie verbruik direct op elke myenergi apparaat of van een extern apparaat met een Harvi energie sensor.

--- a/README.nl.txt
+++ b/README.nl.txt
@@ -1,7 +1,7 @@
-Verbind je Zappi EV lader, je Harvi energie sensor en/of je Eddi energie-omleider met Homey. Met grafieken, 'Insights', en kaarten om flows mee te maken.
+Verbind je Zappi EV lader, je Harvi energie sensor en/of je Eddi energie-omleider met Homey. Bekijk de grafieken in  'Insights' en gebruik kaartjes om flows mee te maken.
 
-Start en stop het laden van je EV handmatig, met een schema, of volgens de voorwaarden/condities uit flows. Via bijv. Tbber kan je prijsgestuurd laden.
+Start en stop het laden van je EV handmatig, met een schema, of volgens de voorwaarden/condities uit flows. Via energieleveranciers zoals bijv. Tibber kan je prijsgestuurd laden.
 
-Bedien je warmwater of ander verwarming met Eddi energie-omleider. Of stel in om je zonnepanelen te gebruiken voor warmwater of om je EV te laden.
+Bedien je warmwater of ander verwarming met Eddi energie-omleider. Of gebruik de energie uit je zonnepanelen voor warmwater of om je EV op te laden.
 
-Monitor stroom en energie verbruik direct op elke myenergi apparaat of van een extern apparaat met een Harvi energie sensor.
+Monitor stroom en energie verbruik direct van elke myenergi apparaat of van een extern apparaat met een Harvi energie sensor.

--- a/drivers/zappi/driver.flow.compose.json
+++ b/drivers/zappi/driver.flow.compose.json
@@ -4,14 +4,16 @@
             "id": "start_charging",
             "title": {
                 "en": "Start charging the car",
-                "no": "Start lading av bilen"
+                "no": "Start lading av bilen",
+                "nl": "Start laden van EV"
             }
         },
         {
             "id": "stop_charging",
             "title": {
                 "en": "Stop charging the car",
-                "no": "Stopp lading av bilen"
+                "no": "Stopp lading av bilen",
+                "nl": "Stop laden van EV"
             }
         }
     ],
@@ -20,11 +22,13 @@
             "id": "is_charging",
             "title": {
                 "en": "Car !{{is|isn't}} charging",
-                "no": "Bilen !{{lader|lader ikke}}"
+                "no": "Bilen !{{lader|lader ikke}}",
+                "no": "EV !{{is|is niet}} aan het laden"
             },
             "hint": {
                 "en": "Checks if the car is currently being charged by Zappi",
-                "no": "Sjekker om bilen blir laded av Zappi"
+                "no": "Sjekker om bilen blir laded av Zappi",
+                "nl": "Controleert of de EV wordt opgeladen door de Zappi"
             }
         }
     ],
@@ -33,22 +37,26 @@
             "id": "charging_started",
             "title": {
                 "en": "Charging started",
-                "no": "Lading startet"
+                "no": "Lading startet",
+                "nl": "Laden gestart"
             },
             "hint": {
                 "en": "When Zappi starts charging the connected car",
-                "no": "Når Zappi starter lading av den tilkoblede bilen"
+                "no": "Når Zappi starter lading av den tilkoblede bilen",
+                "nl": "Wanneer Zappi de verbonden EV begint op te laden"
             }
         },
         {
             "id": "charging_stopped",
             "title": {
                 "en": "Charging stopped",
-                "no": "Lading stoppet"
+                "no": "Lading stoppet",
+                "nl": "Laden gestopt"
             },
             "hint": {
                 "en": "When Zappi stops charging the connected car",
-                "no": "Når Zappi stopper ladingen av den tilkoblede bilen"
+                "no": "Når Zappi stopper ladingen av den tilkoblede bilen",
+                "nl": "Wanneer de Zappi is gestopt met het opladen van de verbonden EV"
             }
         }
     ]

--- a/drivers/zappi/driver.flow.compose.json
+++ b/drivers/zappi/driver.flow.compose.json
@@ -23,7 +23,7 @@
             "title": {
                 "en": "Car !{{is|isn't}} charging",
                 "no": "Bilen !{{lader|lader ikke}}",
-                "no": "EV !{{is|is niet}} aan het laden"
+                "nl": "EV !{{is|is niet}} aan het laden"
             },
             "hint": {
                 "en": "Checks if the car is currently being charged by Zappi",


### PR DESCRIPTION
Hi, I just did the dutch translations and made a pull-request.
Just a few things:
- I’m not sure if the translation is too long/too many characters in '.homeycompose/capabilities/charge_session_consumption.json’, but maybe it is.
- I kept the abbreviations in ‘.homeycompose/capabilities/heater_status.json’, ‘Max Temp’ to match the English and Norwegian.
-  I noticed in ' measure_current_ct<x>.json'. and 'measure_power_ct<x>.json' the translations where already there, the Dutch looks fine to me.

I’m also wondering if the translation for the Harvi is missing? In the app under my Harvi I see ’None’ and ‘Generation’ on the sensor tab. For instance my CT2 is connected to my solarpanels, and it shows 'Generation'. I assume you’ve not yet added a separate translation file yet. If you want you can use these translations;
‘None’ -> ‘Geen’
‘Generation’ -> ‘Opwekking’
‘Grid’ -> ‘Electriciteitsnet’ (or just ‘Net’)

Please verify if I didn't mess up things, and let me know if I can help in any other way.