### PR TITLE
fix Zappi Energy object

### DIFF
--- a/app.json
+++ b/app.json
@@ -870,10 +870,8 @@
         "ev_connected"
       ],
       "energy": {
-        "cumulative": true,
-        "cumulativeCapability": "meter_power",
-        "cumulativeImportedCapability": "meter_power",
-        "cumulativeExportedCapability": "meter_power"
+        "evCharger": true,
+        "meterPowerImportedCapability": "meter_power"
       },
       "capabilitiesOptions": {
         "charge_mode_selector": {

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -101,6 +101,15 @@ export class ZappiDevice extends Device {
     // migrate this device over to the 'evcharger' class if it's still the old one
     await this.migrateClass();
 
+
+    // If energyConfig is not defined or requires an update, request the manifest definition and set the Energy object
+    const energyConfig = this.getEnergy();
+    const driverManifestEnergyObj = this.driver?.manifest.energy;
+    if (Object.keys(energyConfig).length !== Object.keys(driverManifestEnergyObj).length) {
+      this.log('updating ENERGY object to', driverManifestEnergyObj);
+      this.setEnergy(driverManifestEnergyObj).catch(this.error);
+    }
+
     // Make sure capabilities are up to date.
     if (this.detectCapabilityChanges()) {
       await this.InitializeCapabilities().catch(this.error);

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -105,7 +105,7 @@ export class ZappiDevice extends Device {
     // If energyConfig is not defined or requires an update, request the manifest definition and set the Energy object
     const energyConfig = this.getEnergy();
     const driverManifestEnergyObj = this.driver?.manifest.energy;
-    if (Object.keys(energyConfig).length !== Object.keys(driverManifestEnergyObj).length) {
+    if (driverManifestEnergyObj && Object.keys(energyConfig).length !== Object.keys(driverManifestEnergyObj).length) {
       this.log('updating ENERGY object to', driverManifestEnergyObj);
       this.setEnergy(driverManifestEnergyObj).catch(this.error);
     }

--- a/drivers/zappi/driver.compose.json
+++ b/drivers/zappi/driver.compose.json
@@ -27,10 +27,8 @@
     "ev_connected"
   ],
   "energy": {
-    "cumulative": true,
-    "cumulativeCapability": "meter_power",
-    "cumulativeImportedCapability": "meter_power",
-    "cumulativeExportedCapability": "meter_power"
+    "evCharger": true,
+    "meterPowerImportedCapability": "meter_power"
   },
   "capabilitiesOptions": {
     "charge_mode_selector": {


### PR DESCRIPTION
Currently the Zappi charger is not shown in the Homey Energy tab.

Corrected the definition of the Homey Energy object according to https://apps.developer.homey.app/the-basics/devices/energy#ev-chargers-1

Added a migration function in the onInit of the Zappi device driver.

Tested and working correctly in my home setup