### PR TITLE
Add Zappi phase setting control (1/3/auto)

### DIFF
--- a/.homeycompose/capabilities/zappi_phase_setting.json
+++ b/.homeycompose/capabilities/zappi_phase_setting.json
@@ -1,0 +1,46 @@
+{
+    "type": "enum",
+    "title": {
+        "en": "Phase Setting",
+        "no": "Faseinnstilling",
+        "nl": "Fase-instelling",
+        "sv": "Fasinställning",
+        "de": "Phaseneinstellung"
+    },
+    "getable": true,
+    "setable": true,
+    "uiComponent": "picker",
+    "icon": "/assets/accessories.svg",
+    "values": [
+        {
+            "id": "AUTO",
+            "title": {
+                "en": "Auto",
+                "no": "Auto",
+                "nl": "Auto",
+                "sv": "Auto",
+                "de": "Auto"
+            }
+        },
+        {
+            "id": "SINGLE_PHASE",
+            "title": {
+                "en": "Single phase",
+                "no": "Enfase",
+                "nl": "1-fase",
+                "sv": "Enfas",
+                "de": "Einphasig"
+            }
+        },
+        {
+            "id": "THREE_PHASE",
+            "title": {
+                "en": "Three phase",
+                "no": "Trefase",
+                "nl": "3-fase",
+                "sv": "Trefas",
+                "de": "Dreiphasig"
+            }
+        }
+    ]
+}

--- a/app.json
+++ b/app.json
@@ -1564,6 +1564,83 @@
         ]
       },
       {
+        "id": "set_phase_setting",
+        "title": {
+          "en": "Set phase setting",
+          "no": "Still inn faseinnstilling",
+          "nl": "Fase-instelling instellen",
+          "sv": "Ställ in fasinställning",
+          "de": "Phaseneinstellung einstellen"
+        },
+        "hint": {
+          "en": "Switch the Zappi between single phase, three phase or automatic phase charging. Requires a three phase Zappi with firmware that supports phase switching.",
+          "no": "Bytt Zappi mellom enfase, trefase eller automatisk faselading. Krever en trefase Zappi med fastvare som støtter fasebytte.",
+          "nl": "Schakel de Zappi tussen 1-fase, 3-fase of automatisch laden. Vereist een 3-fase Zappi met firmware die fase-omschakeling ondersteunt.",
+          "sv": "Växla Zappi mellan enfas, trefas eller automatisk fasladdning. Kräver en trefas Zappi med fast programvara som stöder fasbyte.",
+          "de": "Schaltet den Zappi zwischen einphasigem, dreiphasigem oder automatischem Laden um. Erfordert einen dreiphasigen Zappi mit Firmware, die Phasenumschaltung unterstützt."
+        },
+        "titleFormatted": {
+          "en": "Set phase setting to [[phase_setting]]",
+          "no": "Still inn faseinnstilling til [[phase_setting]]",
+          "nl": "Stel fase-instelling in op [[phase_setting]]",
+          "sv": "Ställ in fasinställning till [[phase_setting]]",
+          "de": "Phaseneinstellung auf [[phase_setting]] einstellen"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=zappi"
+          },
+          {
+            "type": "dropdown",
+            "name": "phase_setting",
+            "title": {
+              "en": "Phase Setting",
+              "no": "Faseinnstilling",
+              "nl": "Fase-instelling",
+              "sv": "Fasinställning",
+              "de": "Phaseneinstellung"
+            },
+            "placeholder": {
+              "en": "Select a value"
+            },
+            "values": [
+              {
+                "id": "AUTO",
+                "label": {
+                  "en": "Auto",
+                  "no": "Auto",
+                  "nl": "Auto",
+                  "sv": "Auto",
+                  "de": "Auto"
+                }
+              },
+              {
+                "id": "SINGLE_PHASE",
+                "label": {
+                  "en": "Single phase",
+                  "no": "Enfase",
+                  "nl": "1-fase",
+                  "sv": "Enfas",
+                  "de": "Einphasig"
+                }
+              },
+              {
+                "id": "THREE_PHASE",
+                "label": {
+                  "en": "Three phase",
+                  "no": "Trefase",
+                  "nl": "3-fase",
+                  "sv": "Trefas",
+                  "de": "Dreiphasig"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
         "id": "set_boost_mode",
         "title": {
           "en": "Set boost mode",
@@ -2763,6 +2840,52 @@
       "max": 100,
       "step": 1,
       "decimals": 0
+    },
+    "zappi_phase_setting": {
+      "type": "enum",
+      "title": {
+        "en": "Phase Setting",
+        "no": "Faseinnstilling",
+        "nl": "Fase-instelling",
+        "sv": "Fasinställning",
+        "de": "Phaseneinstellung"
+      },
+      "getable": true,
+      "setable": true,
+      "uiComponent": "picker",
+      "icon": "/assets/accessories.svg",
+      "values": [
+        {
+          "id": "AUTO",
+          "title": {
+            "en": "Auto",
+            "no": "Auto",
+            "nl": "Auto",
+            "sv": "Auto",
+            "de": "Auto"
+          }
+        },
+        {
+          "id": "SINGLE_PHASE",
+          "title": {
+            "en": "Single phase",
+            "no": "Enfase",
+            "nl": "1-fase",
+            "sv": "Enfas",
+            "de": "Einphasig"
+          }
+        },
+        {
+          "id": "THREE_PHASE",
+          "title": {
+            "en": "Three phase",
+            "no": "Trefase",
+            "nl": "3-fase",
+            "sv": "Trefas",
+            "de": "Dreiphasig"
+          }
+        }
+      ]
     }
   }
 }

--- a/drivers/zappi/ZappiPhaseSettingText.ts
+++ b/drivers/zappi/ZappiPhaseSettingText.ts
@@ -1,0 +1,6 @@
+
+export enum ZappiPhaseSettingText {
+    Auto = "AUTO",
+    SinglePhase = "SINGLE_PHASE",
+    ThreePhase = "THREE_PHASE"
+}

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -1,5 +1,5 @@
 import { Device } from 'homey';
-import { MyEnergi, Zappi, ZappiBoostMode, ZappiChargeMode, ZappiStatus } from 'myenergi-api';
+import { MyEnergi, Zappi, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, ZappiStatus } from 'myenergi-api';
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { MyEnergiApp } from '../../app';
 import { ZappiSettings } from '../../models/ZappiSettings';
@@ -9,6 +9,7 @@ import { ZappiBoostModeText } from './ZappiBoostModeText';
 import { ZappiChargeModeText } from './ZappiChargeModeText';
 import { ZappiData } from "./ZappiData";
 import { ZappiDeviceState } from './ZappiDeviceState';
+import { ZappiPhaseSettingText } from './ZappiPhaseSettingText';
 import { ZappiStatusText } from './ZappiStatusText';
 
 export class ZappiDevice extends Device {
@@ -43,6 +44,7 @@ export class ZappiDevice extends Device {
     return this._deviceState;
   }
   private _lastChargerStatusText: ZappiStatusText | null = null;
+  private _phaseSetting: ZappiPhaseSettingText | null = null;
   private _boostMode: ZappiBoostMode = ZappiBoostMode.Stop;
   public get boostMode(): ZappiBoostMode {
     return this._boostMode;
@@ -165,6 +167,7 @@ export class ZappiDevice extends Device {
     this.registerCapabilityListener('onoff', this.onCapabilityOnoff.bind(this));
     this.registerCapabilityListener('charge_mode_selector', this.onCapabilityChargeMode.bind(this));
     this.registerCapabilityListener('set_minimum_green_level', this.onCapabilityGreenLevel.bind(this));
+    this.registerCapabilityListener('zappi_phase_setting', this.onCapabilityPhaseSetting.bind(this));
 
     this.registerCapabilityListener('button.reset_meter', async () => {
       this.setCapabilityValue('meter_power', 0);
@@ -261,6 +264,9 @@ export class ZappiDevice extends Device {
     this.setCapabilityValue('zappi_boost_kwh_remaining', (this._boostMode === ZappiBoostMode.Manual ? this._boostManualKwhRemaining : (this._boostMode === ZappiBoostMode.Smart ? this._boostSmartKwhRemaining : 0))).catch(this.error);
     this.setCapabilityValue('zappi_boost_time', `${this._boostSmartTime}`).catch(this.error);
     this.setCapabilityValue('ev_connected', this._chargerStatus !== ZappiStatus.EvDisconnected).catch(this.error);
+    if (this._phaseSetting !== null) {
+      this.setCapabilityValue('zappi_phase_setting', `${this._phaseSetting}`).catch(this.error);
+    }
 
     const meter_power = calculateEnergy(this._lastEnergyCalculation, this._lastChargingPower, this._chargingPower, this.getCapabilityValue('meter_power'));
     this._lastChargingPower = this._chargingPower;
@@ -323,6 +329,7 @@ export class ZappiDevice extends Device {
     this._chargeMode = zappi.zmo;
     this._chargerStatus = zappi.pst as ZappiStatus;
     this._deviceState = (zappi.sta !== undefined && zappi.sta !== null) ? zappi.sta as ZappiDeviceState : ZappiDeviceState.Unknown;
+    this._phaseSetting = this.getPhaseSettingText(zappi.phaseSetting) ?? this._phaseSetting;
     this._chargingPower = 0;
     if ((this._settings.powerCalculationMode === 'automatic' && zappi.ectt1 === 'Internal Load')
       || (this._settings.powerCalculationMode === 'manual' && this._settings.includeCT1)) {
@@ -574,6 +581,54 @@ export class ZappiDevice extends Device {
   }
 
   /**
+   * Set the Zappi phase setting (single phase, three phase or auto).
+   * Requires a three phase Zappi with firmware that supports phase switching.
+   * @param phaseSettingText @type ZappiPhaseSettingText
+   */
+  public async setPhaseSetting(phaseSettingText: ZappiPhaseSettingText): Promise<void> {
+    const phaseSetting = this.getPhaseSetting(phaseSettingText);
+    try {
+      const result = await this.myenergiClient?.setZappiPhaseSetting(this.deviceId, phaseSetting);
+      if (result.status !== 0) {
+        throw new Error(JSON.stringify(result));
+      }
+      this._phaseSetting = phaseSettingText;
+      this.setCapabilityValue('zappi_phase_setting', `${phaseSettingText}`).catch(this.error);
+      this.log(`Zappi phase setting changed to ${phaseSettingText}`);
+    } catch (error) {
+      this.error(`Setting the Zappi phase setting to ${phaseSettingText} failed:\n${error}`);
+      throw new Error(`Setting the phase setting failed. Please check that your Zappi supports phase switching.`, { cause: error });
+    }
+  }
+
+  /**
+   * Convert the phaseSetting status field ("1", "3" or "auto") to the capability text value.
+   */
+  private getPhaseSettingText(value?: string): ZappiPhaseSettingText | null {
+    if (value === '1')
+      return ZappiPhaseSettingText.SinglePhase;
+    else if (value === '3')
+      return ZappiPhaseSettingText.ThreePhase;
+    else if (value === 'auto')
+      return ZappiPhaseSettingText.Auto;
+    return null;
+  }
+
+  /**
+   * Convert the capability text value to the API phase setting.
+   */
+  private getPhaseSetting(value: ZappiPhaseSettingText | string): ZappiPhaseSetting {
+    if (value == ZappiPhaseSettingText.SinglePhase)
+      return ZappiPhaseSetting.SinglePhase;
+    else if (value == ZappiPhaseSettingText.ThreePhase)
+      return ZappiPhaseSetting.ThreePhase;
+    else if (value == ZappiPhaseSettingText.Auto)
+      return ZappiPhaseSetting.Auto;
+    else
+      throw new Error(`Invalid phase setting ${value}`);
+  }
+
+  /**
    * Set Zappi charge mode.
    * @param chargeMode @type ZappiChargeMode
    */
@@ -667,6 +722,16 @@ export class ZappiDevice extends Device {
   private async onCapabilityGreenLevel(value: number, opts: unknown): Promise<void> {
     this.log(`Minimum Green Level: ${value} - ${opts}`);
     await this.setMinimumGreenLevel(value).catch(this.error);
+  }
+
+  /**
+   * Event handler for phase setting capability listener
+   * @param value Phase setting (AUTO, SINGLE_PHASE or THREE_PHASE)
+   * @param opts Options
+   */
+  private async onCapabilityPhaseSetting(value: ZappiPhaseSettingText, opts: unknown): Promise<void> {
+    this.log(`Phase Setting: ${value} - ${opts}`);
+    await this.setPhaseSetting(value);
   }
 
   public getChargeMode(value: ZappiChargeModeText): ZappiChargeMode {

--- a/drivers/zappi/driver.flow.compose.json
+++ b/drivers/zappi/driver.flow.compose.json
@@ -125,6 +125,78 @@
             ]
         },
         {
+            "id": "set_phase_setting",
+            "title": {
+                "en": "Set phase setting",
+                "no": "Still inn faseinnstilling",
+                "nl": "Fase-instelling instellen",
+                "sv": "Ställ in fasinställning",
+                "de": "Phaseneinstellung einstellen"
+            },
+            "hint": {
+                "en": "Switch the Zappi between single phase, three phase or automatic phase charging. Requires a three phase Zappi with firmware that supports phase switching.",
+                "no": "Bytt Zappi mellom enfase, trefase eller automatisk faselading. Krever en trefase Zappi med fastvare som støtter fasebytte.",
+                "nl": "Schakel de Zappi tussen 1-fase, 3-fase of automatisch laden. Vereist een 3-fase Zappi met firmware die fase-omschakeling ondersteunt.",
+                "sv": "Växla Zappi mellan enfas, trefas eller automatisk fasladdning. Kräver en trefas Zappi med fast programvara som stöder fasbyte.",
+                "de": "Schaltet den Zappi zwischen einphasigem, dreiphasigem oder automatischem Laden um. Erfordert einen dreiphasigen Zappi mit Firmware, die Phasenumschaltung unterstützt."
+            },
+            "titleFormatted": {
+                "en": "Set phase setting to [[phase_setting]]",
+                "no": "Still inn faseinnstilling til [[phase_setting]]",
+                "nl": "Stel fase-instelling in op [[phase_setting]]",
+                "sv": "Ställ in fasinställning till [[phase_setting]]",
+                "de": "Phaseneinstellung auf [[phase_setting]] einstellen"
+            },
+            "args": [
+                {
+                    "type": "dropdown",
+                    "name": "phase_setting",
+                    "title": {
+                        "en": "Phase Setting",
+                        "no": "Faseinnstilling",
+                        "nl": "Fase-instelling",
+                        "sv": "Fasinställning",
+                        "de": "Phaseneinstellung"
+                    },
+                    "placeholder": {
+                        "en": "Select a value"
+                    },
+                    "values": [
+                        {
+                            "id": "AUTO",
+                            "label": {
+                                "en": "Auto",
+                                "no": "Auto",
+                                "nl": "Auto",
+                                "sv": "Auto",
+                                "de": "Auto"
+                            }
+                        },
+                        {
+                            "id": "SINGLE_PHASE",
+                            "label": {
+                                "en": "Single phase",
+                                "no": "Enfase",
+                                "nl": "1-fase",
+                                "sv": "Enfas",
+                                "de": "Einphasig"
+                            }
+                        },
+                        {
+                            "id": "THREE_PHASE",
+                            "label": {
+                                "en": "Three phase",
+                                "no": "Trefase",
+                                "nl": "3-fase",
+                                "sv": "Trefas",
+                                "de": "Dreiphasig"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "id": "set_boost_mode",
             "title": {
                 "en": "Set boost mode",

--- a/drivers/zappi/driver.ts
+++ b/drivers/zappi/driver.ts
@@ -45,6 +45,7 @@ export class ZappiDriver extends Driver {
     new Capability('zappi_boost_time', CapabilityType.Sensor, 19),
     new Capability('zappi_boost_kwh_remaining', CapabilityType.Sensor, 20),
     new Capability('ev_connected', CapabilityType.Sensor, 21),
+    new Capability('zappi_phase_setting', CapabilityType.Control, 22),
   ];
 
   public zappiDevices: ZappiData[] = [];
@@ -173,6 +174,18 @@ export class ZappiDriver extends Driver {
       } catch (error) {
         dev.error(error);
       }
+    });
+
+    const setPhaseSettingAction = this.homey.flow.getActionCard('set_phase_setting');
+    setPhaseSettingAction.registerRunListener(async (args, state) => {
+      const dev: ZappiDevice = args.device;
+      if (!dev) {
+        this.error('Unable to detect device on flow: set_phase_setting');
+        return;
+      }
+      dev.log(`Phase Setting: ${args.phase_setting}`);
+      dev.log(`State: ${state}`);
+      await dev.setPhaseSetting(args.phase_setting);
     });
 
     const setMinimumGreenLevelAction = this.homey.flow.getActionCard('set_minimum_green_level');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "myenergi-api": "^2.5.0"
+        "myenergi-api": "github:bisand/myenergi-api#add-zappi-phase-setting"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4186,9 +4186,8 @@
       "license": "ISC"
     },
     "node_modules/myenergi-api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.5.0.tgz",
-      "integrity": "sha512-AM13TVHTuKL2sPFWH9QpF97E4MxZ4YkYgTnkL8/lBDhRIL7HMVAT2URUyzUjqnVnxDA1Got6TyezhAIPlMrIZg==",
+      "version": "2.6.0",
+      "resolved": "git+ssh://git@github.com/bisand/myenergi-api.git#73cc6232b6b89ab4918ba2e1fdb5feec3c14358b",
       "license": "MIT"
     },
     "node_modules/nan": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "myenergi-api": "github:bisand/myenergi-api#add-zappi-phase-setting"
+        "myenergi-api": "^2.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4187,7 +4187,8 @@
     },
     "node_modules/myenergi-api": {
       "version": "2.6.0",
-      "resolved": "git+ssh://git@github.com/bisand/myenergi-api.git#73cc6232b6b89ab4918ba2e1fdb5feec3c14358b",
+      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.6.0.tgz",
+      "integrity": "sha512-OEI3CG1AJhq50D0P2CKbfd7vQJcrN07QyMTODbqidA1xADNkoFvXAFcER5RQGc9XclqZ5+H1VDGu+HPyginU3g==",
       "license": "MIT"
     },
     "node_modules/nan": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript-eslint": "^8.62.1"
   },
   "dependencies": {
-    "myenergi-api": "github:bisand/myenergi-api#add-zappi-phase-setting"
+    "myenergi-api": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript-eslint": "^8.62.1"
   },
   "dependencies": {
-    "myenergi-api": "^2.5.0"
+    "myenergi-api": "github:bisand/myenergi-api#add-zappi-phase-setting"
   }
 }


### PR DESCRIPTION
## Summary

Implements #37 — switching a three phase Zappi between **single phase**, **three phase** and **auto** from Homey:

- New setable `zappi_phase_setting` capability (picker) on the Zappi device, kept in sync from the `phaseSetting` status field on firmware that reports it.
- New **Set phase setting** flow action (Auto / Single phase / Three phase), so a flow can average solar output and pick 1-phase on cloudy days and 3-phase on sunny days — exactly the use case from the issue.
- Uses the `cgi-zappi-phase-setting` endpoint via `setZappiPhaseSetting()` added in bisand/myenergi-api#13. The endpoint values (0=1-phase, 1=3-phase, 2=auto) match the community-proven implementation shipped in pymyenergi / the Home Assistant integration.
- On Zappis without phase switching support the action fails with a descriptive error instead of crashing.

## Before merging

- [x] Merge bisand/myenergi-api#13 and create a **v2.6.0 release** there (published to npm via Trusted Publishing)
- [x] Switch `package.json` from the git branch reference back to `"myenergi-api": "^2.6.0"`
- [ ] Test on real three phase hardware — the issue reporters (@tkroon89, @mroeben) offered to test

## Testing

- `tsc`, ESLint and `homey app validate --level publish` pass.
- Library change covered by a nock unit test (suite 10/10).
- Smoke tested on a Homey Pro: existing Zappi device migrates and gains the new capability, app initializes with zero errors.
- **Not** tested against real three phase hardware (author's install is single phase) — needs community testing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
