### PR TITLE
Expose per-CT power and a separate house power group on Zappi

### DIFF
--- a/.homeycompose/capabilities/ct4_type.json
+++ b/.homeycompose/capabilities/ct4_type.json
@@ -1,0 +1,10 @@
+{
+    "type": "string",
+    "title": {
+        "en": "CT4"
+    },
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "icon": "/assets/ct_clamp1.svg"
+}

--- a/.homeycompose/capabilities/ct5_type.json
+++ b/.homeycompose/capabilities/ct5_type.json
@@ -1,0 +1,10 @@
+{
+    "type": "string",
+    "title": {
+        "en": "CT5"
+    },
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "icon": "/assets/ct_clamp1.svg"
+}

--- a/.homeycompose/capabilities/ct6_type.json
+++ b/.homeycompose/capabilities/ct6_type.json
@@ -1,0 +1,10 @@
+{
+    "type": "string",
+    "title": {
+        "en": "CT6"
+    },
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "icon": "/assets/ct_clamp1.svg"
+}

--- a/.homeycompose/capabilities/measure_power_ct4.json
+++ b/.homeycompose/capabilities/measure_power_ct4.json
@@ -1,0 +1,80 @@
+{
+    "type": "number",
+    "title": {
+      "en": "Power CT4",
+      "nl": "Vermogen CT4",
+      "de": "Leistung CT4",
+      "fr": "Puissance CT4",
+      "it": "Potenza CT4",
+      "sv": "Effekt CT4",
+      "no": "Effekt CT4",
+      "es": "Potencia CT4",
+      "da": "Effekt CT4"
+    },
+    "units": {
+      "en": "W"
+    },
+    "icon": "/assets/ct_clamp2.svg",
+    "insights": true,
+    "desc": {
+      "en": "Power in Watt (W)",
+      "nl": "Vermogen in Watt (W)",
+      "de": "Leistung in Watt (W)",
+      "fr": "Puissance  en Watt (W)",
+      "it": "Potenza in Watt (W)",
+      "sv": "Effekt i watt (W)",
+      "no": "Effekt i watt (W)",
+      "es": "Potencia en vatios (W)",
+      "da": "Effekt i Watt (W)"
+    },
+    "options": {
+      "isApproximated": {
+        "type": "boolean",
+        "default": false,
+        "desc": {
+          "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+        }
+      }
+    },
+    "chartType": "stepLine",
+    "decimals": 2,
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "$flow": {
+      "triggers": [
+        {
+          "id": "measure_power_changed",
+          "title": {
+            "en": "The power changed",
+            "nl": "Het vermogen is veranderd",
+            "de": "Der Verbrauch hat sich gändert",
+            "fr": "L'énergie a changé",
+            "it": "L'energia è cambiata",
+            "sv": "Strömmen ändrades",
+            "no": "Strømmen ble endret",
+            "es": "La potencia ha cambiado",
+            "da": "Strømmen ændrede sig"
+          },
+          "tokens": [
+            {
+              "name": "measure_power",
+              "title": {
+                "en": "Power",
+                "nl": "Vermogen",
+                "de": "Leistung",
+                "fr": "Puissance",
+                "it": "Potenza",
+                "sv": "Effekt",
+                "no": "Effekt",
+                "es": "Potencia",
+                "da": "Effekt"
+              },
+              "type": "number",
+              "example": 7.5
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/.homeycompose/capabilities/measure_power_ct5.json
+++ b/.homeycompose/capabilities/measure_power_ct5.json
@@ -1,0 +1,80 @@
+{
+    "type": "number",
+    "title": {
+      "en": "Power CT5",
+      "nl": "Vermogen CT5",
+      "de": "Leistung CT5",
+      "fr": "Puissance CT5",
+      "it": "Potenza CT5",
+      "sv": "Effekt CT5",
+      "no": "Effekt CT5",
+      "es": "Potencia CT5",
+      "da": "Effekt CT5"
+    },
+    "units": {
+      "en": "W"
+    },
+    "icon": "/assets/ct_clamp2.svg",
+    "insights": true,
+    "desc": {
+      "en": "Power in Watt (W)",
+      "nl": "Vermogen in Watt (W)",
+      "de": "Leistung in Watt (W)",
+      "fr": "Puissance  en Watt (W)",
+      "it": "Potenza in Watt (W)",
+      "sv": "Effekt i watt (W)",
+      "no": "Effekt i watt (W)",
+      "es": "Potencia en vatios (W)",
+      "da": "Effekt i Watt (W)"
+    },
+    "options": {
+      "isApproximated": {
+        "type": "boolean",
+        "default": false,
+        "desc": {
+          "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+        }
+      }
+    },
+    "chartType": "stepLine",
+    "decimals": 2,
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "$flow": {
+      "triggers": [
+        {
+          "id": "measure_power_changed",
+          "title": {
+            "en": "The power changed",
+            "nl": "Het vermogen is veranderd",
+            "de": "Der Verbrauch hat sich gändert",
+            "fr": "L'énergie a changé",
+            "it": "L'energia è cambiata",
+            "sv": "Strömmen ändrades",
+            "no": "Strømmen ble endret",
+            "es": "La potencia ha cambiado",
+            "da": "Strømmen ændrede sig"
+          },
+          "tokens": [
+            {
+              "name": "measure_power",
+              "title": {
+                "en": "Power",
+                "nl": "Vermogen",
+                "de": "Leistung",
+                "fr": "Puissance",
+                "it": "Potenza",
+                "sv": "Effekt",
+                "no": "Effekt",
+                "es": "Potencia",
+                "da": "Effekt"
+              },
+              "type": "number",
+              "example": 7.5
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/.homeycompose/capabilities/measure_power_ct6.json
+++ b/.homeycompose/capabilities/measure_power_ct6.json
@@ -1,0 +1,80 @@
+{
+    "type": "number",
+    "title": {
+      "en": "Power CT6",
+      "nl": "Vermogen CT6",
+      "de": "Leistung CT6",
+      "fr": "Puissance CT6",
+      "it": "Potenza CT6",
+      "sv": "Effekt CT6",
+      "no": "Effekt CT6",
+      "es": "Potencia CT6",
+      "da": "Effekt CT6"
+    },
+    "units": {
+      "en": "W"
+    },
+    "icon": "/assets/ct_clamp2.svg",
+    "insights": true,
+    "desc": {
+      "en": "Power in Watt (W)",
+      "nl": "Vermogen in Watt (W)",
+      "de": "Leistung in Watt (W)",
+      "fr": "Puissance  en Watt (W)",
+      "it": "Potenza in Watt (W)",
+      "sv": "Effekt i watt (W)",
+      "no": "Effekt i watt (W)",
+      "es": "Potencia en vatios (W)",
+      "da": "Effekt i Watt (W)"
+    },
+    "options": {
+      "isApproximated": {
+        "type": "boolean",
+        "default": false,
+        "desc": {
+          "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+        }
+      }
+    },
+    "chartType": "stepLine",
+    "decimals": 2,
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "$flow": {
+      "triggers": [
+        {
+          "id": "measure_power_changed",
+          "title": {
+            "en": "The power changed",
+            "nl": "Het vermogen is veranderd",
+            "de": "Der Verbrauch hat sich gändert",
+            "fr": "L'énergie a changé",
+            "it": "L'energia è cambiata",
+            "sv": "Strömmen ändrades",
+            "no": "Strømmen ble endret",
+            "es": "La potencia ha cambiado",
+            "da": "Strømmen ændrede sig"
+          },
+          "tokens": [
+            {
+              "name": "measure_power",
+              "title": {
+                "en": "Power",
+                "nl": "Vermogen",
+                "de": "Leistung",
+                "fr": "Puissance",
+                "it": "Potenza",
+                "sv": "Effekt",
+                "no": "Effekt",
+                "es": "Potencia",
+                "da": "Effekt"
+              },
+              "type": "number",
+              "example": 7.5
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/.homeycompose/capabilities/measure_power_house.json
+++ b/.homeycompose/capabilities/measure_power_house.json
@@ -1,0 +1,55 @@
+{
+    "type": "number",
+    "title": {
+      "en": "House Power",
+      "nl": "Huisvermogen",
+      "de": "Hausleistung",
+      "sv": "Huseffekt",
+      "no": "Huseffekt"
+    },
+    "units": {
+      "en": "W"
+    },
+    "icon": "/assets/ct_clamp2.svg",
+    "insights": true,
+    "desc": {
+      "en": "Combined power of the CT clamps selected in the House consumption settings",
+      "nl": "Gecombineerd vermogen van de CT-klemmen geselecteerd in de instellingen voor huisverbruik",
+      "de": "Kombinierte Leistung der in den Hausverbrauchseinstellungen ausgewählten CT-Klemmen",
+      "sv": "Kombinerad effekt för de CT-klämmor som valts i inställningarna för husförbrukning",
+      "no": "Kombinert effekt for CT-klemmene valgt i innstillingene for husforbruk"
+    },
+    "chartType": "stepLine",
+    "decimals": 2,
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor",
+    "$flow": {
+      "triggers": [
+        {
+          "id": "measure_power_house_changed",
+          "title": {
+            "en": "The house power changed",
+            "nl": "Het huisvermogen is veranderd",
+            "de": "Die Hausleistung hat sich geändert",
+            "sv": "Huseffekten ändrades",
+            "no": "Huseffekten ble endret"
+          },
+          "tokens": [
+            {
+              "name": "measure_power_house",
+              "title": {
+                "en": "House Power",
+                "nl": "Huisvermogen",
+                "de": "Hausleistung",
+                "sv": "Huseffekt",
+                "no": "Huseffekt"
+              },
+              "type": "number",
+              "example": 750
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/app.json
+++ b/app.json
@@ -1174,6 +1174,139 @@
         {
           "type": "group",
           "label": {
+            "en": "House power (second CT group)",
+            "no": "Huseffekt (andre CT-gruppe)",
+            "nl": "Huisvermogen (tweede CT-groep)",
+            "de": "Hausleistung (zweite CT-Gruppe)",
+            "sv": "Huseffekt (andra CT-gruppen)"
+          },
+          "hint": {
+            "en": "Combine a second group of CT clamps into the separate House Power value, independent of the charger power calculation. Useful when house or grid CT clamps are connected to the Zappi.",
+            "no": "Kombiner en ekstra gruppe CT-klemmer til den separate Huseffekt-verdien, uavhengig av ladeeffektberegningen. Nyttig når hus- eller nett-CT-klemmer er koblet til Zappi.",
+            "nl": "Combineer een tweede groep CT-klemmen tot de aparte Huisvermogen-waarde, onafhankelijk van de laadvermogenberekening. Handig wanneer huis- of net-CT-klemmen op de Zappi zijn aangesloten.",
+            "de": "Kombinieren Sie eine zweite Gruppe von CT-Klemmen zum separaten Hausleistungswert, unabhängig von der Ladeleistungsberechnung. Nützlich, wenn Haus- oder Netz-CT-Klemmen an den Zappi angeschlossen sind.",
+            "sv": "Kombinera en andra grupp CT-klämmor till det separata Huseffekt-värdet, oberoende av laddningseffektberäkningen. Användbart när hus- eller nät-CT-klämmor är anslutna till Zappi."
+          },
+          "children": [
+            {
+              "id": "includeHouseCT1",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 1",
+                "no": "Inkludere CT 1",
+                "nl": "CT 1 meenemen",
+                "de": "Inklusive CT 1",
+                "sv": "Inkludera CT 1"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 1 in the house power calculation.",
+                "no": "Inkludere CT 1 i beregningen av huseffekt.",
+                "nl": "CT 1 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 1 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 1 i beräkningen av huseffekt."
+              }
+            },
+            {
+              "id": "includeHouseCT2",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 2",
+                "no": "Inkludere CT 2",
+                "nl": "CT 2 meenemen",
+                "de": "Inklusive CT 2",
+                "sv": "Inkludera CT 2"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 2 in the house power calculation.",
+                "no": "Inkludere CT 2 i beregningen av huseffekt.",
+                "nl": "CT 2 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 2 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 2 i beräkningen av huseffekt."
+              }
+            },
+            {
+              "id": "includeHouseCT3",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 3",
+                "no": "Inkludere CT 3",
+                "nl": "CT 3 meenemen",
+                "de": "Inklusive CT 3",
+                "sv": "Inkludera CT 3"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 3 in the house power calculation.",
+                "no": "Inkludere CT 3 i beregningen av huseffekt.",
+                "nl": "CT 3 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 3 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 3 i beräkningen av huseffekt."
+              }
+            },
+            {
+              "id": "includeHouseCT4",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 4",
+                "no": "Inkludere CT 4",
+                "nl": "CT 4 meenemen",
+                "de": "Inklusive CT 4",
+                "sv": "Inkludera CT 4"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 4 in the house power calculation.",
+                "no": "Inkludere CT 4 i beregningen av huseffekt.",
+                "nl": "CT 4 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 4 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 4 i beräkningen av huseffekt."
+              }
+            },
+            {
+              "id": "includeHouseCT5",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 5",
+                "no": "Inkludere CT 5",
+                "nl": "CT 5 meenemen",
+                "de": "Inklusive CT 5",
+                "sv": "Inkludera CT 5"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 5 in the house power calculation.",
+                "no": "Inkludere CT 5 i beregningen av huseffekt.",
+                "nl": "CT 5 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 5 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 5 i beräkningen av huseffekt."
+              }
+            },
+            {
+              "id": "includeHouseCT6",
+              "type": "checkbox",
+              "label": {
+                "en": "Include CT 6",
+                "no": "Inkludere CT 6",
+                "nl": "CT 6 meenemen",
+                "de": "Inklusive CT 6",
+                "sv": "Inkludera CT 6"
+              },
+              "value": false,
+              "hint": {
+                "en": "Include CT 6 in the house power calculation.",
+                "no": "Inkludere CT 6 i beregningen av huseffekt.",
+                "nl": "CT 6 meenemen in de berekening van het huisvermogen.",
+                "de": "Beziehen Sie CT 6 in die Berechnung der Hausleistung ein.",
+                "sv": "Inkludera CT 6 i beräkningen av huseffekt."
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
             "en": "Other",
             "no": "Annen",
             "nl": "Ander",
@@ -2094,6 +2227,36 @@
       "uiComponent": "sensor",
       "icon": "/assets/ct_clamp1.svg"
     },
+    "ct4_type": {
+      "type": "string",
+      "title": {
+        "en": "CT4"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "icon": "/assets/ct_clamp1.svg"
+    },
+    "ct5_type": {
+      "type": "string",
+      "title": {
+        "en": "CT5"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "icon": "/assets/ct_clamp1.svg"
+    },
+    "ct6_type": {
+      "type": "string",
+      "title": {
+        "en": "CT6"
+      },
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor",
+      "icon": "/assets/ct_clamp1.svg"
+    },
     "ev_connected": {
       "type": "boolean",
       "title": {
@@ -2514,6 +2677,138 @@
       "setable": false,
       "uiComponent": "sensor"
     },
+    "measure_power_ct4": {
+      "type": "number",
+      "title": {
+        "en": "Power CT4",
+        "nl": "Vermogen CT4",
+        "de": "Leistung CT4",
+        "fr": "Puissance CT4",
+        "it": "Potenza CT4",
+        "sv": "Effekt CT4",
+        "no": "Effekt CT4",
+        "es": "Potencia CT4",
+        "da": "Effekt CT4"
+      },
+      "units": {
+        "en": "W"
+      },
+      "icon": "/assets/ct_clamp2.svg",
+      "insights": true,
+      "desc": {
+        "en": "Power in Watt (W)",
+        "nl": "Vermogen in Watt (W)",
+        "de": "Leistung in Watt (W)",
+        "fr": "Puissance  en Watt (W)",
+        "it": "Potenza in Watt (W)",
+        "sv": "Effekt i watt (W)",
+        "no": "Effekt i watt (W)",
+        "es": "Potencia en vatios (W)",
+        "da": "Effekt i Watt (W)"
+      },
+      "options": {
+        "isApproximated": {
+          "type": "boolean",
+          "default": false,
+          "desc": {
+            "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+          }
+        }
+      },
+      "chartType": "stepLine",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
+    "measure_power_ct5": {
+      "type": "number",
+      "title": {
+        "en": "Power CT5",
+        "nl": "Vermogen CT5",
+        "de": "Leistung CT5",
+        "fr": "Puissance CT5",
+        "it": "Potenza CT5",
+        "sv": "Effekt CT5",
+        "no": "Effekt CT5",
+        "es": "Potencia CT5",
+        "da": "Effekt CT5"
+      },
+      "units": {
+        "en": "W"
+      },
+      "icon": "/assets/ct_clamp2.svg",
+      "insights": true,
+      "desc": {
+        "en": "Power in Watt (W)",
+        "nl": "Vermogen in Watt (W)",
+        "de": "Leistung in Watt (W)",
+        "fr": "Puissance  en Watt (W)",
+        "it": "Potenza in Watt (W)",
+        "sv": "Effekt i watt (W)",
+        "no": "Effekt i watt (W)",
+        "es": "Potencia en vatios (W)",
+        "da": "Effekt i Watt (W)"
+      },
+      "options": {
+        "isApproximated": {
+          "type": "boolean",
+          "default": false,
+          "desc": {
+            "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+          }
+        }
+      },
+      "chartType": "stepLine",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
+    "measure_power_ct6": {
+      "type": "number",
+      "title": {
+        "en": "Power CT6",
+        "nl": "Vermogen CT6",
+        "de": "Leistung CT6",
+        "fr": "Puissance CT6",
+        "it": "Potenza CT6",
+        "sv": "Effekt CT6",
+        "no": "Effekt CT6",
+        "es": "Potencia CT6",
+        "da": "Effekt CT6"
+      },
+      "units": {
+        "en": "W"
+      },
+      "icon": "/assets/ct_clamp2.svg",
+      "insights": true,
+      "desc": {
+        "en": "Power in Watt (W)",
+        "nl": "Vermogen in Watt (W)",
+        "de": "Leistung in Watt (W)",
+        "fr": "Puissance  en Watt (W)",
+        "it": "Potenza in Watt (W)",
+        "sv": "Effekt i watt (W)",
+        "no": "Effekt i watt (W)",
+        "es": "Potencia en vatios (W)",
+        "da": "Effekt i Watt (W)"
+      },
+      "options": {
+        "isApproximated": {
+          "type": "boolean",
+          "default": false,
+          "desc": {
+            "en": "This flag is used to determine that the device itself has no power measurement functionality, but that the driver calculates the energy use."
+          }
+        }
+      },
+      "chartType": "stepLine",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
     "measure_power_diverted": {
       "type": "number",
       "title": {
@@ -2551,6 +2846,33 @@
       "icon": "/assets/solar_wind_power.svg",
       "min": 0,
       "decimals": 2
+    },
+    "measure_power_house": {
+      "type": "number",
+      "title": {
+        "en": "House Power",
+        "nl": "Huisvermogen",
+        "de": "Hausleistung",
+        "sv": "Huseffekt",
+        "no": "Huseffekt"
+      },
+      "units": {
+        "en": "W"
+      },
+      "icon": "/assets/ct_clamp2.svg",
+      "insights": true,
+      "desc": {
+        "en": "Combined power of the CT clamps selected in the House consumption settings",
+        "nl": "Gecombineerd vermogen van de CT-klemmen geselecteerd in de instellingen voor huisverbruik",
+        "de": "Kombinierte Leistung der in den Hausverbrauchseinstellungen ausgewählten CT-Klemmen",
+        "sv": "Kombinerad effekt för de CT-klämmor som valts i inställningarna för husförbrukning",
+        "no": "Kombinert effekt for CT-klemmene valgt i innstillingene for husforbruk"
+      },
+      "chartType": "stepLine",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
     },
     "meter_power_ct1": {
       "type": "number",

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -60,6 +60,9 @@ export class ZappiDevice extends Device {
     this._lastBoostState = value;
   }
   private _lastEvConnected = false;
+  private _ctPowers: number[] = [0, 0, 0, 0, 0, 0];
+  private _ctTypes: string[] = ['None', 'None', 'None', 'None', 'None', 'None'];
+  private _housePower = 0;
   private _boostManualKwh = 0;
   private _boostSmartKwh = 0;
   private _boostManualKwhRemaining = 0;
@@ -267,6 +270,11 @@ export class ZappiDevice extends Device {
     if (this._phaseSetting !== null) {
       this.setCapabilityValue('zappi_phase_setting', `${this._phaseSetting}`).catch(this.error);
     }
+    this.setCapabilityValue('measure_power_house', this._housePower).catch(this.error);
+    for (let i = 0; i < 6; i++) {
+      this.setCapabilityValue(`ct${i + 1}_type`, this._ctTypes[i]).catch(this.error);
+      this.setCapabilityValue(`measure_power_ct${i + 1}`, this._ctPowers[i]).catch(this.error);
+    }
 
     const meter_power = calculateEnergy(this._lastEnergyCalculation, this._lastChargingPower, this._chargingPower, this.getCapabilityValue('meter_power'));
     this._lastChargingPower = this._chargingPower;
@@ -358,6 +366,20 @@ export class ZappiDevice extends Device {
 
     if (this._settings.showNegativeValues === false) {
       this._chargingPower = this._chargingPower > 0 ? this._chargingPower : 0;
+    }
+
+    this._ctPowers = [zappi.ectp1, zappi.ectp2, zappi.ectp3, zappi.ectp4, zappi.ectp5, zappi.ectp6].map(power => power ? power : 0);
+    this._ctTypes = [zappi.ectt1, zappi.ectt2, zappi.ectt3, zappi.ectt4, zappi.ectt5, zappi.ectt6].map(type => type ? type : 'None');
+
+    this._housePower = 0;
+    if (this._settings.includeHouseCT1) this._housePower += this._ctPowers[0];
+    if (this._settings.includeHouseCT2) this._housePower += this._ctPowers[1];
+    if (this._settings.includeHouseCT3) this._housePower += this._ctPowers[2];
+    if (this._settings.includeHouseCT4) this._housePower += this._ctPowers[3];
+    if (this._settings.includeHouseCT5) this._housePower += this._ctPowers[4];
+    if (this._settings.includeHouseCT6) this._housePower += this._ctPowers[5];
+    if (this._settings.showNegativeValues === false) {
+      this._housePower = this._housePower > 0 ? this._housePower : 0;
     }
 
     this._chargingVoltage = zappi.vol ? (zappi.vol / 10) : 0;
@@ -841,6 +863,24 @@ export class ZappiDevice extends Device {
     this.log(`ZappiDevice settings where changed: ${changedKeys}`);
     if (changedKeys.includes('showNegativeValues')) {
       this._settings.showNegativeValues = newSettings.showNegativeValues;
+    }
+    if (changedKeys.includes('includeHouseCT1')) {
+      this._settings.includeHouseCT1 = newSettings.includeHouseCT1;
+    }
+    if (changedKeys.includes('includeHouseCT2')) {
+      this._settings.includeHouseCT2 = newSettings.includeHouseCT2;
+    }
+    if (changedKeys.includes('includeHouseCT3')) {
+      this._settings.includeHouseCT3 = newSettings.includeHouseCT3;
+    }
+    if (changedKeys.includes('includeHouseCT4')) {
+      this._settings.includeHouseCT4 = newSettings.includeHouseCT4;
+    }
+    if (changedKeys.includes('includeHouseCT5')) {
+      this._settings.includeHouseCT5 = newSettings.includeHouseCT5;
+    }
+    if (changedKeys.includes('includeHouseCT6')) {
+      this._settings.includeHouseCT6 = newSettings.includeHouseCT6;
     }
     if (changedKeys.includes('powerCalculationMode')) {
       this._settings.powerCalculationMode = newSettings.powerCalculationMode;

--- a/drivers/zappi/driver.settings.compose.json
+++ b/drivers/zappi/driver.settings.compose.json
@@ -237,6 +237,139 @@
     {
         "type": "group",
         "label": {
+            "en": "House power (second CT group)",
+            "no": "Huseffekt (andre CT-gruppe)",
+            "nl": "Huisvermogen (tweede CT-groep)",
+            "de": "Hausleistung (zweite CT-Gruppe)",
+            "sv": "Huseffekt (andra CT-gruppen)"
+        },
+        "hint": {
+            "en": "Combine a second group of CT clamps into the separate House Power value, independent of the charger power calculation. Useful when house or grid CT clamps are connected to the Zappi.",
+            "no": "Kombiner en ekstra gruppe CT-klemmer til den separate Huseffekt-verdien, uavhengig av ladeeffektberegningen. Nyttig når hus- eller nett-CT-klemmer er koblet til Zappi.",
+            "nl": "Combineer een tweede groep CT-klemmen tot de aparte Huisvermogen-waarde, onafhankelijk van de laadvermogenberekening. Handig wanneer huis- of net-CT-klemmen op de Zappi zijn aangesloten.",
+            "de": "Kombinieren Sie eine zweite Gruppe von CT-Klemmen zum separaten Hausleistungswert, unabhängig von der Ladeleistungsberechnung. Nützlich, wenn Haus- oder Netz-CT-Klemmen an den Zappi angeschlossen sind.",
+            "sv": "Kombinera en andra grupp CT-klämmor till det separata Huseffekt-värdet, oberoende av laddningseffektberäkningen. Användbart när hus- eller nät-CT-klämmor är anslutna till Zappi."
+        },
+        "children": [
+            {
+                "id": "includeHouseCT1",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 1",
+                    "no": "Inkludere CT 1",
+                    "nl": "CT 1 meenemen",
+                    "de": "Inklusive CT 1",
+                    "sv": "Inkludera CT 1"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 1 in the house power calculation.",
+                    "no": "Inkludere CT 1 i beregningen av huseffekt.",
+                    "nl": "CT 1 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 1 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 1 i beräkningen av huseffekt."
+                }
+            },
+            {
+                "id": "includeHouseCT2",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 2",
+                    "no": "Inkludere CT 2",
+                    "nl": "CT 2 meenemen",
+                    "de": "Inklusive CT 2",
+                    "sv": "Inkludera CT 2"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 2 in the house power calculation.",
+                    "no": "Inkludere CT 2 i beregningen av huseffekt.",
+                    "nl": "CT 2 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 2 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 2 i beräkningen av huseffekt."
+                }
+            },
+            {
+                "id": "includeHouseCT3",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 3",
+                    "no": "Inkludere CT 3",
+                    "nl": "CT 3 meenemen",
+                    "de": "Inklusive CT 3",
+                    "sv": "Inkludera CT 3"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 3 in the house power calculation.",
+                    "no": "Inkludere CT 3 i beregningen av huseffekt.",
+                    "nl": "CT 3 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 3 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 3 i beräkningen av huseffekt."
+                }
+            },
+            {
+                "id": "includeHouseCT4",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 4",
+                    "no": "Inkludere CT 4",
+                    "nl": "CT 4 meenemen",
+                    "de": "Inklusive CT 4",
+                    "sv": "Inkludera CT 4"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 4 in the house power calculation.",
+                    "no": "Inkludere CT 4 i beregningen av huseffekt.",
+                    "nl": "CT 4 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 4 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 4 i beräkningen av huseffekt."
+                }
+            },
+            {
+                "id": "includeHouseCT5",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 5",
+                    "no": "Inkludere CT 5",
+                    "nl": "CT 5 meenemen",
+                    "de": "Inklusive CT 5",
+                    "sv": "Inkludera CT 5"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 5 in the house power calculation.",
+                    "no": "Inkludere CT 5 i beregningen av huseffekt.",
+                    "nl": "CT 5 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 5 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 5 i beräkningen av huseffekt."
+                }
+            },
+            {
+                "id": "includeHouseCT6",
+                "type": "checkbox",
+                "label": {
+                    "en": "Include CT 6",
+                    "no": "Inkludere CT 6",
+                    "nl": "CT 6 meenemen",
+                    "de": "Inklusive CT 6",
+                    "sv": "Inkludera CT 6"
+                },
+                "value": false,
+                "hint": {
+                    "en": "Include CT 6 in the house power calculation.",
+                    "no": "Inkludere CT 6 i beregningen av huseffekt.",
+                    "nl": "CT 6 meenemen in de berekening van het huisvermogen.",
+                    "de": "Beziehen Sie CT 6 in die Berechnung der Hausleistung ein.",
+                    "sv": "Inkludera CT 6 i beräkningen av huseffekt."
+                }
+            }
+        ]
+    },
+    {
+        "type": "group",
+        "label": {
             "en": "Other",
             "no": "Annen",
             "nl": "Ander",

--- a/drivers/zappi/driver.ts
+++ b/drivers/zappi/driver.ts
@@ -46,6 +46,19 @@ export class ZappiDriver extends Driver {
     new Capability('zappi_boost_kwh_remaining', CapabilityType.Sensor, 20),
     new Capability('ev_connected', CapabilityType.Sensor, 21),
     new Capability('zappi_phase_setting', CapabilityType.Control, 22),
+    new Capability('measure_power_house', CapabilityType.Sensor, 23),
+    new Capability('ct1_type', CapabilityType.Sensor, 24),
+    new Capability('measure_power_ct1', CapabilityType.Sensor, 25),
+    new Capability('ct2_type', CapabilityType.Sensor, 26),
+    new Capability('measure_power_ct2', CapabilityType.Sensor, 27),
+    new Capability('ct3_type', CapabilityType.Sensor, 28),
+    new Capability('measure_power_ct3', CapabilityType.Sensor, 29),
+    new Capability('ct4_type', CapabilityType.Sensor, 30),
+    new Capability('measure_power_ct4', CapabilityType.Sensor, 31),
+    new Capability('ct5_type', CapabilityType.Sensor, 32),
+    new Capability('measure_power_ct5', CapabilityType.Sensor, 33),
+    new Capability('ct6_type', CapabilityType.Sensor, 34),
+    new Capability('measure_power_ct6', CapabilityType.Sensor, 35),
   ];
 
   public zappiDevices: ZappiData[] = [];

--- a/models/ZappiSettings.ts
+++ b/models/ZappiSettings.ts
@@ -6,6 +6,12 @@ export interface ZappiSettings {
   includeCT4?: boolean;
   includeCT5?: boolean;
   includeCT6?: boolean;
+  includeHouseCT1?: boolean;
+  includeHouseCT2?: boolean;
+  includeHouseCT3?: boolean;
+  includeHouseCT4?: boolean;
+  includeHouseCT5?: boolean;
+  includeHouseCT6?: boolean;
   showNegativeValues?: boolean;
   totalEnergyOffset?: number;
   siteName?: string;


### PR DESCRIPTION
## Summary

Implements #51 — measure EV charging **and** house consumption from the same Zappi:

- **Per-CT sensors** (`ct1_type`–`ct6_type`, `measure_power_ct1`–`ct6`), mirroring the existing Harvi pattern. Each clamp is individually visible and usable as a flow tag — also covers the request to watch 3-phase balance per clamp.
- **House power group**: a new settings group with six checkboxes selects which CTs make up the separate `measure_power_house` value (insights enabled, own "house power changed" flow trigger). Completely independent of the charger's `measure_power` calculation, so CT1–3 can feed charger power while CT4–6 feed house power.
- `showNegativeValues` applies to the house group the same way it does to charger power.

## Testing

- `tsc`, ESLint and `homey app validate --level publish` pass.
- Smoke tested on a Homey Pro: existing Zappi device migrates, gains all 13 new capabilities, and populates values with zero errors.
- Needs real-world verification by users with house CTs on the Zappi (@supermicke and @Hovhag offered to test in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)