### PR TITLE
Add Charged Today sensor from myenergi historic data

### DIFF
--- a/.homeycompose/capabilities/charge_energy_today.json
+++ b/.homeycompose/capabilities/charge_energy_today.json
@@ -1,0 +1,27 @@
+{
+    "type": "number",
+    "title": {
+      "en": "Charged Today",
+      "no": "Ladet i dag",
+      "nl": "Vandaag geladen",
+      "sv": "Laddat idag",
+      "de": "Heute geladen"
+    },
+    "units": {
+      "en": "kWh"
+    },
+    "icon": "/assets/charge_session_consumption.svg",
+    "insights": true,
+    "desc": {
+      "en": "Energy delivered by the charger today, from myenergi historic data. Resets at midnight (Homey's time zone).",
+      "no": "Energi levert av laderen i dag, fra myenergi historiske data. Nullstilles ved midnatt (Homeys tidssone).",
+      "nl": "Energie die de lader vandaag heeft geleverd, uit historische myenergi-gegevens. Reset om middernacht (tijdzone van Homey).",
+      "sv": "Energi som laddaren levererat idag, från myenergi historiska data. Nollställs vid midnatt (Homeys tidszon).",
+      "de": "Heute vom Ladegerät gelieferte Energie, aus historischen myenergi-Daten. Wird um Mitternacht zurückgesetzt (Zeitzone von Homey)."
+    },
+    "chartType": "spline",
+    "decimals": 2,
+    "getable": true,
+    "setable": false,
+    "uiComponent": "sensor"
+  }

--- a/app.json
+++ b/app.json
@@ -1828,6 +1828,33 @@
     ]
   },
   "capabilities": {
+    "charge_energy_today": {
+      "type": "number",
+      "title": {
+        "en": "Charged Today",
+        "no": "Ladet i dag",
+        "nl": "Vandaag geladen",
+        "sv": "Laddat idag",
+        "de": "Heute geladen"
+      },
+      "units": {
+        "en": "kWh"
+      },
+      "icon": "/assets/charge_session_consumption.svg",
+      "insights": true,
+      "desc": {
+        "en": "Energy delivered by the charger today, from myenergi historic data. Resets at midnight (Homey's time zone).",
+        "no": "Energi levert av laderen i dag, fra myenergi historiske data. Nullstilles ved midnatt (Homeys tidssone).",
+        "nl": "Energie die de lader vandaag heeft geleverd, uit historische myenergi-gegevens. Reset om middernacht (tijdzone van Homey).",
+        "sv": "Energi som laddaren levererat idag, från myenergi historiska data. Nollställs vid midnatt (Homeys tidszon).",
+        "de": "Heute vom Ladegerät gelieferte Energie, aus historischen myenergi-Daten. Wird um Mitternacht zurückgesetzt (Zeitzone von Homey)."
+      },
+      "chartType": "spline",
+      "decimals": 2,
+      "getable": true,
+      "setable": false,
+      "uiComponent": "sensor"
+    },
     "charge_mode": {
       "type": "enum",
       "title": {

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -649,17 +649,22 @@ export class ZappiDevice extends Device {
    */
   public async setPhaseSetting(phaseSettingText: ZappiPhaseSettingText): Promise<void> {
     const phaseSetting = this.getPhaseSetting(phaseSettingText);
+    let serverReason = '';
     try {
       const result = await this.myenergiClient?.setZappiPhaseSetting(this.deviceId, phaseSetting);
       if (result.status !== 0) {
-        throw new Error(JSON.stringify(result));
+        // Failed requests may carry the server's reason, e.g. "Only Zappi 2 supported"
+        if (typeof result?.body === 'string' && result.body.length > 0) {
+          serverReason = result.body;
+        }
+        throw new Error(serverReason || JSON.stringify(result));
       }
       this._phaseSetting = phaseSettingText;
       this.setCapabilityValue('zappi_phase_setting', `${phaseSettingText}`).catch(this.error);
       this.log(`Zappi phase setting changed to ${phaseSettingText}`);
     } catch (error) {
       this.error(`Setting the Zappi phase setting to ${phaseSettingText} failed:\n${error}`);
-      throw new Error(`Setting the phase setting failed. Please check that your Zappi supports phase switching.`, { cause: error });
+      throw new Error(`Setting the phase setting failed${serverReason ? ` (${serverReason})` : ''}. Please check that your Zappi supports phase switching.`, { cause: error });
     }
   }
 

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -60,6 +60,7 @@ export class ZappiDevice extends Device {
     this._lastBoostState = value;
   }
   private _lastEvConnected = false;
+  private _lastChargedTodayFetch: Date | null = null;
   private _ctPowers: number[] = [0, 0, 0, 0, 0, 0];
   private _ctTypes: string[] = ['None', 'None', 'None', 'None', 'None', 'None'];
   private _housePower = 0;
@@ -565,6 +566,45 @@ export class ZappiDevice extends Device {
           }
         }
       });
+      this.updateChargedToday().catch(this.error);
+    }
+  }
+
+  /**
+   * Update the "Charged Today" value from myenergi historic data.
+   * Sums the diverted and boosted energy since midnight in Homey's time
+   * zone. Historic data lags a few minutes behind live data and is
+   * cached by the server, so the value is refreshed at most every 15
+   * minutes.
+   */
+  private async updateChargedToday(): Promise<void> {
+    const now = new Date();
+    if (this._lastChargedTodayFetch && (now.getTime() - this._lastChargedTodayFetch.getTime()) < 15 * 60 * 1000)
+      return;
+    this._lastChargedTodayFetch = now;
+    try {
+      const timeZone = this.homey.clock.getTimezone();
+      const localNow = new Date(now.toLocaleString('en-US', { timeZone }));
+      const msSinceLocalMidnight = ((localNow.getHours() * 60 + localNow.getMinutes()) * 60 + localNow.getSeconds()) * 1000;
+      const utcStartOfLocalDay = new Date(now.getTime() - msSinceLocalMidnight);
+      const noHours = Math.min(24, Math.ceil(msSinceLocalMidnight / 3600000) + 1);
+      const records = await this.myenergiClient?.getDayHourHistory(
+        `Z${this.deviceId}`,
+        utcStartOfLocalDay.getUTCFullYear(),
+        utcStartOfLocalDay.getUTCMonth() + 1,
+        utcStartOfLocalDay.getUTCDate(),
+        utcStartOfLocalDay.getUTCHours(),
+        noHours);
+      if (records && records.length > 0) {
+        const joules = records.reduce((sum, record) =>
+          sum + (record.h1d ?? 0) + (record.h1b ?? 0) + (record.h2d ?? 0) + (record.h2b ?? 0) + (record.h3d ?? 0) + (record.h3b ?? 0), 0);
+        const chargedToday = joules / 3600000;
+        this.setCapabilityValue('charge_energy_today', Math.round(chargedToday * 100) / 100).catch(this.error);
+      } else {
+        this.setCapabilityValue('charge_energy_today', 0).catch(this.error);
+      }
+    } catch (error) {
+      this.error(`Updating charged today failed:\n${error}`);
     }
   }
 

--- a/drivers/zappi/driver.ts
+++ b/drivers/zappi/driver.ts
@@ -59,6 +59,7 @@ export class ZappiDriver extends Driver {
     new Capability('measure_power_ct5', CapabilityType.Sensor, 33),
     new Capability('ct6_type', CapabilityType.Sensor, 34),
     new Capability('measure_power_ct6', CapabilityType.Sensor, 35),
+    new Capability('charge_energy_today', CapabilityType.Sensor, 36),
   ];
 
   public zappiDevices: ZappiData[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "myenergi-api": "^2.6.0"
+        "myenergi-api": "^2.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4186,9 +4186,9 @@
       "license": "ISC"
     },
     "node_modules/myenergi-api": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.6.0.tgz",
-      "integrity": "sha512-OEI3CG1AJhq50D0P2CKbfd7vQJcrN07QyMTODbqidA1xADNkoFvXAFcER5RQGc9XclqZ5+H1VDGu+HPyginU3g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.7.0.tgz",
+      "integrity": "sha512-lKuovsJ17uGQE+oPEp+jAeUHT6pklVYaMXh7W85Z7V5BCcxklmsJfmtMKTKeKnr8pB4OGH3cu7uuJ2bSlu5Ctg==",
       "license": "MIT"
     },
     "node_modules/nan": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript-eslint": "^8.62.1"
   },
   "dependencies": {
-    "myenergi-api": "^2.6.0"
+    "myenergi-api": "^2.7.0"
   }
 }

--- a/services/MyEnergiFake.ts
+++ b/services/MyEnergiFake.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Eddi, EddiBoost, EddiMode, Harvi, MyEnergi, Zappi, ZappiBoostMode, ZappiChargeMode } from 'myenergi-api';
+import { Eddi, EddiBoost, EddiMode, Harvi, HistoryRecord, MyEnergi, Zappi, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting } from 'myenergi-api';
 import { AppKeyValues } from 'myenergi-api/dist/src/models/AppKeyValues';
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { getFakeEddiData, getFakeHarviData, getFakeZappiData } from '../tools';
 
 export class MyEnergiFake extends MyEnergi {
     private _fakeEddiMode: EddiMode;
+    private _fakePhaseSetting = 'auto';
     constructor(username: string, password: string, apiBaseUrl?: string) {
         super(username, password, apiBaseUrl);
         this._fakeEddiMode = EddiMode.On;
@@ -15,7 +16,7 @@ export class MyEnergiFake extends MyEnergi {
             console.log(`MyEnergiFake->getStatusAll()`);
             const result = [];
             result.push({ eddi: Array(1).fill(getFakeEddiData(99999997, this._fakeEddiMode)) });
-            result.push({ zappi: Array(1).fill(getFakeZappiData()) });
+            result.push({ zappi: Array(1).fill(getFakeZappiData(undefined, this._fakePhaseSetting)) });
             result.push({ harvi: Array(1).fill(getFakeHarviData()) });
             resolve(result);
         });
@@ -24,14 +25,14 @@ export class MyEnergiFake extends MyEnergi {
         return new Promise<any>((resolve) => {
             console.log(`MyEnergiFake->getStatusZappiAll()`);
             const result = [];
-            result.push(getFakeZappiData());
+            result.push(getFakeZappiData(undefined, this._fakePhaseSetting));
             resolve(result);
         });
     }
     public override getStatusZappi(serialNumber: string): Promise<Zappi | null> {
         return new Promise<any>((resolve) => {
             console.log(`MyEnergiFake->getStatusZappi(${serialNumber})`);
-            resolve(getFakeZappiData(Number(serialNumber)));
+            resolve(getFakeZappiData(Number(serialNumber), this._fakePhaseSetting));
         });
     }
     public override setZappiChargeMode(serialNo: string, chargeMode: ZappiChargeMode): Promise<any> {
@@ -50,6 +51,32 @@ export class MyEnergiFake extends MyEnergi {
         return new Promise<any>((resolve) => {
             console.log(`MyEnergiFake->setZappiGreenLevel(${serialNo}, ${percentage})`);
             resolve({ status: 0, statustext: "" });
+        });
+    }
+    public override setZappiPhaseSetting(serialNo: string, phaseSetting: ZappiPhaseSetting): Promise<any> {
+        return new Promise<any>((resolve) => {
+            console.log(`MyEnergiFake->setZappiPhaseSetting(${serialNo}, ${phaseSetting})`);
+            this._fakePhaseSetting = phaseSetting === ZappiPhaseSetting.SinglePhase ? '1' : (phaseSetting === ZappiPhaseSetting.ThreePhase ? '3' : 'auto');
+            resolve({ status: 0, statustext: "" });
+        });
+    }
+    public override getDayHourHistory(id: string, year: number, month: number, day: number, startHour?: number, noHours?: number): Promise<HistoryRecord[]> {
+        return new Promise<HistoryRecord[]>((resolve) => {
+            console.log(`MyEnergiFake->getDayHourHistory(${id}, ${year}-${month}-${day}, ${startHour}, ${noHours})`);
+            const hours = noHours ?? 24;
+            const records: HistoryRecord[] = [];
+            for (let i = 0; i < hours; i++) {
+                records.push({
+                    hr: ((startHour ?? 0) + i) % 24,
+                    dom: day,
+                    mon: month,
+                    yr: year,
+                    imp: 3600000,
+                    h1d: 1800000,
+                    h1b: 900000,
+                });
+            }
+            resolve(records);
         });
     }
     public override getStatusEddiAll(): Promise<Eddi[]> {

--- a/tools.ts
+++ b/tools.ts
@@ -89,26 +89,6 @@ export function getFakeEddi(myenergiClientId: string, id: string, name: string):
     };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function includeFakeData(data: any) {
-    if (process.env.DEBUG !== '1')
-        return data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = data.reduce((a: any, c: any) => {
-        if (c.eddi) {
-            c.eddi.push(getFakeEddiData());
-        }
-        if (c.zappi) {
-            c.zappi.push(getFakeZappiData());
-        }
-        if (c.harvi) {
-            c.harvi.push(getFakeHarviData());
-        }
-        a.push(c);
-        return a;
-    }, []);
-    return result;
-}
 
 export function getFakeZappiData(serialNumber = 99999999, phaseSetting = "auto") {
     return { "sno": serialNumber, "dat": getDate(), "tim": getTime(), "ectp2": -3, "ectt1": "Internal Load", "ectt2": "None", "ectt3": "None", "bsm": 0, "bst": 0, "cmt": 255, "dst": 1, "div": 0, "frq": getRandom(51, 49), "fwv": "3300S0.000", "grd": getRandomInt(10000), "pha": 1, "pri": 1, "sta": 1, "tz": 0, "vol": getRandomInt(2400, 2200), "che": 59.91, "bss": 0, "lck": 0, "pst": "A", "zmo": 1, "zs": 20, "rdc": 3, "rac": 1, "rrac": 2, "zsl": 20, "ectt4": "None", "ectt5": "None", "ectt6": "None", "newAppAvailable": false, "newBootloaderAvailable": false, "beingTamperedWith": false, "batteryDischargeEnabled": false, "mgl": 32, "sbh": 6, "sbk": 22, "sbm": 15, "phaseSetting": phaseSetting };

--- a/tools.ts
+++ b/tools.ts
@@ -110,8 +110,8 @@ export function includeFakeData(data: any) {
     return result;
 }
 
-export function getFakeZappiData(serialNumber = 99999999) {
-    return { "sno": serialNumber, "dat": getDate(), "tim": getTime(), "ectp2": -3, "ectt1": "Internal Load", "ectt2": "None", "ectt3": "None", "bsm": 0, "bst": 0, "cmt": 255, "dst": 1, "div": 0, "frq": getRandom(51, 49), "fwv": "3300S0.000", "grd": getRandomInt(10000), "pha": 1, "pri": 1, "sta": 1, "tz": 0, "vol": getRandomInt(2400, 2200), "che": 59.91, "bss": 0, "lck": 0, "pst": "A", "zmo": 1, "zs": 20, "rdc": 3, "rac": 1, "rrac": 2, "zsl": 20, "ectt4": "None", "ectt5": "None", "ectt6": "None", "newAppAvailable": false, "newBootloaderAvailable": false, "beingTamperedWith": false, "batteryDischargeEnabled": false, "mgl": 32, "sbh": 6, "sbk": 22, "sbm": 15 };
+export function getFakeZappiData(serialNumber = 99999999, phaseSetting = "auto") {
+    return { "sno": serialNumber, "dat": getDate(), "tim": getTime(), "ectp2": -3, "ectt1": "Internal Load", "ectt2": "None", "ectt3": "None", "bsm": 0, "bst": 0, "cmt": 255, "dst": 1, "div": 0, "frq": getRandom(51, 49), "fwv": "3300S0.000", "grd": getRandomInt(10000), "pha": 1, "pri": 1, "sta": 1, "tz": 0, "vol": getRandomInt(2400, 2200), "che": 59.91, "bss": 0, "lck": 0, "pst": "A", "zmo": 1, "zs": 20, "rdc": 3, "rac": 1, "rrac": 2, "zsl": 20, "ectt4": "None", "ectt5": "None", "ectt6": "None", "newAppAvailable": false, "newBootloaderAvailable": false, "beingTamperedWith": false, "batteryDischargeEnabled": false, "mgl": 32, "sbh": 6, "sbk": 22, "sbm": 15, "phaseSetting": phaseSetting };
 }
 
 export function getFakeHarviData(serialNumber = 99999998) {


### PR DESCRIPTION
## Summary

Implements #57 — a **Charged Today** sensor (kWh, with insights) on the Zappi device:

- Computed from myenergi's **historic data API** (`cgi-jdayhour`, added as `getDayHourHistory()` in myenergi-api 2.7.0, bisand/myenergi-api#14) — the authoritative per-hour energy figures, not local power integration, so it can't drift or spike across restarts (the failure mode reported in #53).
- Sums diverted + boosted energy (`h1d/h1b/h2d/h2b/h3d/h3b`) since midnight in **Homey's time zone**; resets naturally at midnight.
- Refreshed at most every 15 minutes, piggybacking on the existing data-update cycle (historic data lags live data slightly and is server-cached, so more frequent polling adds nothing).
- Usable directly as a flow tag — e.g. capture the value just before midnight to log daily charging, the exact use case in the issue.

Also partially addresses #82 (energy per time interval); the same library method supports arbitrary date ranges for a fuller implementation there.

## Testing

- Library method covered by a nock unit test (suite 11/11); published as myenergi-api 2.7.0 via Trusted Publishing.
- `tsc`, ESLint and `homey app validate --level publish` pass.
- Smoke tested on a Homey Pro: capability migrates onto the existing Zappi, history fetch runs without errors.
- Real-world numbers should be sanity checked against the myenergi phone app's daily figure by someone with an actively charging Zappi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)