### PR TITLE
Expose Eddi temperature probes as sensors

### DIFF
--- a/app.json
+++ b/app.json
@@ -147,6 +147,8 @@
         "heater_2_name",
         "measure_voltage",
         "measure_frequency",
+        "measure_temperature.tp1",
+        "measure_temperature.tp2",
         "button.reset_meter",
         "button.reset_meter_ct1",
         "button.reset_meter_ct2",
@@ -161,6 +163,24 @@
         "cumulativeExportedCapability": "meter_power"
       },
       "capabilitiesOptions": {
+        "measure_temperature.tp1": {
+          "title": {
+            "en": "Temperature probe 1",
+            "no": "Temperaturføler 1",
+            "nl": "Temperatuursensor 1",
+            "sv": "Temperatursond 1",
+            "de": "Temperaturfühler 1"
+          }
+        },
+        "measure_temperature.tp2": {
+          "title": {
+            "en": "Temperature probe 2",
+            "no": "Temperaturføler 2",
+            "nl": "Temperatuursensor 2",
+            "sv": "Temperatursond 2",
+            "de": "Temperaturfühler 2"
+          }
+        },
         "button.reset_meter": {
           "maintenanceAction": true,
           "title": {

--- a/drivers/eddi/device.ts
+++ b/drivers/eddi/device.ts
@@ -29,6 +29,8 @@ export class EddiDevice extends Device {
   private _gridPower = 0;
   private _generatedPower = 0;
   private _divertedPower = 0;
+  private _tp1: number | null = null;
+  private _tp2: number | null = null;
   private _settings!: EddiSettings;
   private _powerCalculationModeSetToAuto!: boolean;
 
@@ -191,6 +193,8 @@ export class EddiDevice extends Device {
     this._ct1Current = (this._systemVoltage > 0) ? (this._ct1Power / this._systemVoltage) : 0; // P=U*I -> I=P/U
     this._ct2Current = (this._systemVoltage > 0) ? (this._ct2Power / this._systemVoltage) : 0; // P=U*I -> I=P/U
     this._ct3Current = (this._systemVoltage > 0) ? (this._ct3Power / this._systemVoltage) : 0; // P=U*I -> I=P/U
+    this._tp1 = this.getValidTemperature(eddi.tp1);
+    this._tp2 = this.getValidTemperature(eddi.tp2);
 
     if (this._powerCalculationModeSetToAuto) {
       this._powerCalculationModeSetToAuto = false;
@@ -204,8 +208,19 @@ export class EddiDevice extends Device {
     }
   }
 
+  /**
+   * Temperature probes report -1 when no probe is connected and 127 when
+   * the reading is invalid. Return null for those so the sensor shows as
+   * unknown instead of a bogus temperature.
+   */
+  private getValidTemperature(value?: number): number | null {
+    return (value === undefined || value === null || value <= -1 || value >= 127) ? null : value;
+  }
+
   private setCapabilityValues() {
     this.setCapabilityValue('onoff', this._onOff !== EddiMode.Off).catch(this.error);
+    this.setCapabilityValue('measure_temperature.tp1', this._tp1).catch(this.error);
+    this.setCapabilityValue('measure_temperature.tp2', this._tp2).catch(this.error);
     this.setCapabilityValue('heater_status', `${this._heaterStatus}`).catch(this.error);
     this.setCapabilityValue('heater_1_name', `${this._heater1Name}`).catch(this.error);
     this.setCapabilityValue('heater_2_name', `${this._heater2Name}`).catch(this.error);

--- a/drivers/eddi/driver.compose.json
+++ b/drivers/eddi/driver.compose.json
@@ -27,6 +27,8 @@
     "heater_2_name",
     "measure_voltage",
     "measure_frequency",
+    "measure_temperature.tp1",
+    "measure_temperature.tp2",
     "button.reset_meter",
     "button.reset_meter_ct1",
     "button.reset_meter_ct2",
@@ -41,6 +43,24 @@
     "cumulativeExportedCapability": "meter_power"
   },
   "capabilitiesOptions": {
+    "measure_temperature.tp1": {
+      "title": {
+        "en": "Temperature probe 1",
+        "no": "Temperaturføler 1",
+        "nl": "Temperatuursensor 1",
+        "sv": "Temperatursond 1",
+        "de": "Temperaturfühler 1"
+      }
+    },
+    "measure_temperature.tp2": {
+      "title": {
+        "en": "Temperature probe 2",
+        "no": "Temperaturføler 2",
+        "nl": "Temperatuursensor 2",
+        "sv": "Temperatursond 2",
+        "de": "Temperaturfühler 2"
+      }
+    },
     "button.reset_meter": {
       "maintenanceAction": true,
       "title": {

--- a/drivers/eddi/driver.ts
+++ b/drivers/eddi/driver.ts
@@ -42,6 +42,8 @@ export class EddiDriver extends Driver {
     new Capability('button.reset_meter_ct3', CapabilityType.Control, 27),
     new Capability('button.reset_meter_generated', CapabilityType.Control, 28),
     new Capability('button.reload_capabilities', CapabilityType.Control, 29),
+    new Capability('measure_temperature.tp1', CapabilityType.Sensor, 30),
+    new Capability('measure_temperature.tp2', CapabilityType.Sensor, 31),
   ];
 
   public eddiDevices: EddiData[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "net.biseth.myenergi",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "net.biseth.myenergi",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "GPL-3.0",
       "dependencies": {
-        "myenergi-api": "^2.7.0"
+        "myenergi-api": "^2.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -4186,9 +4186,9 @@
       "license": "ISC"
     },
     "node_modules/myenergi-api": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.7.0.tgz",
-      "integrity": "sha512-lKuovsJ17uGQE+oPEp+jAeUHT6pklVYaMXh7W85Z7V5BCcxklmsJfmtMKTKeKnr8pB4OGH3cu7uuJ2bSlu5Ctg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/myenergi-api/-/myenergi-api-2.7.1.tgz",
+      "integrity": "sha512-y2NGmXI9Yp/I4Hv2UeUetiLEkmBUTT8mKaEXqN8bGHARDEVUZaebuIC5w4YbVKGATWM/s2fWHcUeDNuwzBouVA==",
       "license": "MIT"
     },
     "node_modules/nan": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "typescript-eslint": "^8.62.1"
   },
   "dependencies": {
-    "myenergi-api": "^2.7.0"
+    "myenergi-api": "^2.7.1"
   }
 }


### PR DESCRIPTION
## Summary

Implements #65 — the Eddi's two temperature probes (`tp1`/`tp2`) are now exposed as standard **measure_temperature** sub-capabilities ("Temperature probe 1"/"2"), with Insights and flow conditions included, enabling automations like the reporter's tank-to-tank pump control.

- Contrary to the assumption in the issue, the API does report these (the Eddi status carries `tp1`/`tp2` in °C) — the library model just had a typo (`tp` instead of `tp1`), fixed in myenergi-api **2.7.1** (bisand/myenergi-api#15).
- Invalid readings (`-1` = no probe connected, `127` = invalid) render as *unknown* rather than fake temperatures.

## Testing

- `tsc`, ESLint, `homey app validate --level publish` pass; app runs on a Homey Pro with zero errors.
- No Eddi hardware available to the author — needs verification by an Eddi owner (@Jfrederikse2 offered the use case in the issue). The dev-mode fake Eddi reports plausible probe values for UI testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)