### PR TITLE
Reject invalid hub credentials at save time; clarify setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,18 @@
 
 Adds support for myenergi products like Zappi, Eddi and Harvy. You will be able to monitor and control your devices using Homey. Start and stop charging of your EV or control your water heater based on energy prices from [Tibber](https://invite.tibber.com/3ea6e31f) or total power consumption in your home. 
 
-To be able to use this Homey app you will need a [hub from myenergi](https://myenergi.com/product/hub/) installed and connected to the internet.
+This app talks to your myenergi devices through the myenergi cloud. Your devices must therefore be connected to the internet, either through a myenergi hub (older installations — the standalone hub is no longer sold) or through the built-in hub functionality of newer Zappi and Eddi devices connected via Wi-Fi/Ethernet.
 
 ## Installation
 Install the [latest version](https://homey.app/no-no/app/net.biseth.myenergi/myenergi/) of myenergi app for Homey from the Homey App Store. (A [beta version](https://homey.app/no-no/app/net.biseth.myenergi/myenergi/test) is also available for those who like to live on the edge.)
 
 ## Usage
-After installing the app on your Homey you will have to register your hub. You can do that in the app settings for the newly installed app (More -> Apps -> myenergi -> Configure app)
+After installing the app on your Homey you will have to register your hub credentials before devices can be added. Open the app settings (More -> Apps -> myenergi -> Configure app) and enter:
+
+- **Hub serial no**: the serial number of your myenergi **hub**. If your Zappi/Eddi connects to the internet without a separate hub (built-in hub), use the serial number of that device instead. You can find it under "Live products" on [myaccount.myenergi.com](https://myaccount.myenergi.com).
+- **API key**: generate one on [myaccount.myenergi.com](https://myaccount.myenergi.com) under your device's **Advanced settings**. Note that your myenergi account password will **not** work.
+
+The hub itself does not appear as a device in Homey — it is only the connection. Once the credentials are saved successfully, add your Zappi, Eddi or Harvi devices via *Devices -> + -> myenergi*.
 
 ## Support
 Feel free to ask questions, suggest new features or bug reports in the [issues section](https://github.com/bisand/net.biseth.myenergi/issues) of this repository.

--- a/app.ts
+++ b/app.ts
@@ -88,7 +88,10 @@ export class MyEnergiApp extends Homey.App {
       const client = new MyEnergi(username, password, apiBaseUrl);
       const data = await client.getStatusAll().catch(this.error);
       this.log(`Credential check: ${JSON.stringify(data)}`);
-      if (data && Array.isArray(data)) {
+      // The API client returns an empty array when authentication fails,
+      // while a successful request always contains at least one entry
+      // (the active server name). An empty result means bad credentials.
+      if (data && Array.isArray(data) && data.length > 0) {
         return true;
       }
     } catch (error) {

--- a/settings/index.html
+++ b/settings/index.html
@@ -39,7 +39,7 @@
         <legend>myenergi API base URI</legend>
 
         <div class="field row">
-            <label for="apiBaseUrl">Hub name</label>
+            <label for="apiBaseUrl">API base URL</label>
             <input id="apiBaseUrl" name="apiBaseUrl" type="text" value="" placeholder="https://s18.myenergi.net" required
                 pattern="/(https?:\/\/)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g" />
         </div>
@@ -48,6 +48,18 @@
     <fieldset class="fieldset" id="fieldset-1">
         <legend>myenergi Hub</legend>
         <div class="container">
+            <p style="font-size: 0.85em;">
+                <i>
+                    <b>Serial no:</b> the serial number of your myenergi <b>hub</b>. If your Zappi/Eddi
+                    connects to the internet without a separate hub (built-in hub), use the serial
+                    number of that device instead. You can find it under "Live products" on
+                    <a href="https://myaccount.myenergi.com" target="_blank">myaccount.myenergi.com</a>.<br />
+                    <b>API key:</b> generate one on
+                    <a href="https://myaccount.myenergi.com" target="_blank">myaccount.myenergi.com</a>
+                    under your device's <b>Advanced settings</b>. Your myenergi account password will
+                    <b>not</b> work here.
+                </i>
+            </p>
             <div class="field row">
                 <label for="hubname">Hub name</label>
                 <input id="hubname" name="hubname" type="text" value="" required pattern="[a-zA-Z0-9]+" />
@@ -57,7 +69,7 @@
                 <input id="username" name="username" type="text" value="" required pattern="[0-9]*" inputmode="numeric" />
             </div>
             <div class="field row">
-                <label for="password">Hub password</label>
+                <label for="password">API key (hub password)</label>
                 <input id="password" name="password" type="password" value="" />
             </div>
             <div class="field row">
@@ -255,7 +267,7 @@
                         saveHubs.push(res.result === 'ok');
                         if (res.result !== 'ok') {
                             $(`#fieldset-${fieldsetId}`).css({ 'background-color': 'orange' });
-                            Homey.alert(`Failed to authenticate hub ${hub.hubname} with serial ${hub.username}`);
+                            Homey.alert(`Failed to authenticate hub ${hub.hubname} with serial ${hub.username}.\n\nPlease check that:\n- The serial number is that of your hub (or of the Zappi/Eddi itself if it has a built-in hub)\n- The API key was generated under Advanced settings on myaccount.myenergi.com (your account password will not work)`);
                             return;
                         }
                         $(`#fieldset-${fieldsetId}`).css({ 'background-color': '' });


### PR DESCRIPTION
## Summary

Fixes #68, fixes #80, fixes #86. Addresses #87 and #88 (docs).

The root cause behind the recurring "no new devices have been found" reports: the credential check counted the API client's **empty-array error result as a success**, so wrong credentials — typically the myenergi *account password* instead of an API key, or a device serial instead of the hub serial — were saved with a green confirmation. The failure then surfaced later, disconnected from its cause, as an empty pairing list.

- `checkCredential` now requires a non-empty status response (a valid login always returns at least the active server entry), so bad credentials fail **at save time** with an orange highlight and an actionable message.
- Settings page: inline help explaining where the hub serial lives (and that hub-less devices use their own serial), how to generate the API key on myaccount.myenergi.com, and that the account password will not work. Also fixes the API base URL field that was mislabeled "Hub name".
- README rewritten for the current reality: the standalone hub is no longer sold (#88), newer devices have a built-in hub, and the hub is a credential rather than a pairable device (#87).

## Testing

- Validated at publish level; credential rejection exercised via the same code path the settings page calls (`/login/` → `validateCredentials` → `checkCredential`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)