### PR TITLE
Add EV connected and charge mode flow conditions

### DIFF
--- a/app.json
+++ b/app.json
@@ -1998,6 +1998,101 @@
             "filter": "driver_id=zappi"
           }
         ]
+      },
+      {
+        "id": "ev_is_connected",
+        "title": {
+          "en": "An EV !{{is|isn't}} connected",
+          "no": "En elbil !{{er|er ikke}} tilkoblet",
+          "nl": "Er !{{is|is geen}} EV aangesloten",
+          "sv": "En elbil !{{är|är inte}} ansluten",
+          "de": "Ein EV !{{ist|ist nicht}} verbunden"
+        },
+        "hint": {
+          "en": "Checks if an EV is connected to the Zappi",
+          "no": "Sjekker om en elbil er koblet til Zappi",
+          "nl": "Controleert of er een EV op de Zappi is aangesloten",
+          "sv": "Kontrollerar om en elbil är ansluten till Zappi",
+          "de": "Überprüft, ob ein EV mit dem Zappi verbunden ist"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=zappi"
+          }
+        ]
+      },
+      {
+        "id": "charge_mode_is",
+        "title": {
+          "en": "Charge mode !{{is|isn't}}",
+          "no": "Lademodus !{{er|er ikke}}",
+          "nl": "Laadmodus !{{is|is niet}}",
+          "sv": "Laddningsläget !{{är|är inte}}",
+          "de": "Lademodus !{{ist|ist nicht}}"
+        },
+        "titleFormatted": {
+          "en": "Charge mode !{{is|isn't}} [[charge_mode]]",
+          "no": "Lademodus !{{er|er ikke}} [[charge_mode]]",
+          "nl": "Laadmodus !{{is|is niet}} [[charge_mode]]",
+          "sv": "Laddningsläget !{{är|är inte}} [[charge_mode]]",
+          "de": "Lademodus !{{ist|ist nicht}} [[charge_mode]]"
+        },
+        "hint": {
+          "en": "Checks the current charge mode of the Zappi",
+          "no": "Sjekker gjeldende lademodus på Zappi",
+          "nl": "Controleert de huidige laadmodus van de Zappi",
+          "sv": "Kontrollerar Zappis aktuella laddningsläge",
+          "de": "Überprüft den aktuellen Lademodus des Zappi"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=zappi"
+          },
+          {
+            "type": "dropdown",
+            "name": "charge_mode",
+            "title": {
+              "en": "Charge Mode",
+              "no": "Lademodus",
+              "nl": "Laadmodus",
+              "sv": "Laddningsläge",
+              "de": "Lademodus"
+            },
+            "placeholder": {
+              "en": "Select a value"
+            },
+            "values": [
+              {
+                "id": "FAST",
+                "label": {
+                  "en": "Fast"
+                }
+              },
+              {
+                "id": "ECO",
+                "label": {
+                  "en": "Eco"
+                }
+              },
+              {
+                "id": "ECO_PLUS",
+                "label": {
+                  "en": "Eco+"
+                }
+              },
+              {
+                "id": "OFF",
+                "label": {
+                  "en": "Off"
+                }
+              }
+            ]
+          }
+        ]
       }
     ]
   },

--- a/drivers/zappi/driver.flow.compose.json
+++ b/drivers/zappi/driver.flow.compose.json
@@ -261,6 +261,89 @@
                 "sv": "Kontrollerar om bilen för närvarande laddas av Zappi",
                 "de": "Überprüft, ob das EV gerade von Zappi geladen wird"
             }
+        },
+        {
+            "id": "ev_is_connected",
+            "title": {
+                "en": "An EV !{{is|isn't}} connected",
+                "no": "En elbil !{{er|er ikke}} tilkoblet",
+                "nl": "Er !{{is|is geen}} EV aangesloten",
+                "sv": "En elbil !{{är|är inte}} ansluten",
+                "de": "Ein EV !{{ist|ist nicht}} verbunden"
+            },
+            "hint": {
+                "en": "Checks if an EV is connected to the Zappi",
+                "no": "Sjekker om en elbil er koblet til Zappi",
+                "nl": "Controleert of er een EV op de Zappi is aangesloten",
+                "sv": "Kontrollerar om en elbil är ansluten till Zappi",
+                "de": "Überprüft, ob ein EV mit dem Zappi verbunden ist"
+            }
+        },
+        {
+            "id": "charge_mode_is",
+            "title": {
+                "en": "Charge mode !{{is|isn't}}",
+                "no": "Lademodus !{{er|er ikke}}",
+                "nl": "Laadmodus !{{is|is niet}}",
+                "sv": "Laddningsläget !{{är|är inte}}",
+                "de": "Lademodus !{{ist|ist nicht}}"
+            },
+            "titleFormatted": {
+                "en": "Charge mode !{{is|isn't}} [[charge_mode]]",
+                "no": "Lademodus !{{er|er ikke}} [[charge_mode]]",
+                "nl": "Laadmodus !{{is|is niet}} [[charge_mode]]",
+                "sv": "Laddningsläget !{{är|är inte}} [[charge_mode]]",
+                "de": "Lademodus !{{ist|ist nicht}} [[charge_mode]]"
+            },
+            "hint": {
+                "en": "Checks the current charge mode of the Zappi",
+                "no": "Sjekker gjeldende lademodus på Zappi",
+                "nl": "Controleert de huidige laadmodus van de Zappi",
+                "sv": "Kontrollerar Zappis aktuella laddningsläge",
+                "de": "Überprüft den aktuellen Lademodus des Zappi"
+            },
+            "args": [
+                {
+                    "type": "dropdown",
+                    "name": "charge_mode",
+                    "title": {
+                        "en": "Charge Mode",
+                        "no": "Lademodus",
+                        "nl": "Laadmodus",
+                        "sv": "Laddningsläge",
+                        "de": "Lademodus"
+                    },
+                    "placeholder": {
+                        "en": "Select a value"
+                    },
+                    "values": [
+                        {
+                            "id": "FAST",
+                            "label": {
+                                "en": "Fast"
+                            }
+                        },
+                        {
+                            "id": "ECO",
+                            "label": {
+                                "en": "Eco"
+                            }
+                        },
+                        {
+                            "id": "ECO_PLUS",
+                            "label": {
+                                "en": "Eco+"
+                            }
+                        },
+                        {
+                            "id": "OFF",
+                            "label": {
+                                "en": "Off"
+                            }
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "triggers": [

--- a/drivers/zappi/driver.ts
+++ b/drivers/zappi/driver.ts
@@ -1,6 +1,6 @@
 import { Driver, FlowCardTriggerDevice } from 'homey';
 import { Device } from 'homey/lib/FlowCardTriggerDevice';
-import { MyEnergi, ZappiChargeMode } from 'myenergi-api';
+import { MyEnergi, ZappiChargeMode, ZappiStatus } from 'myenergi-api';
 import { AppKeyValues } from 'myenergi-api/dist/src/models/AppKeyValues';
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { MyEnergiApp } from '../../app';
@@ -99,6 +99,28 @@ export class ZappiDriver extends Driver {
       const statusText = dev.getChargerStatusText(dev.chargerStatus, dev.deviceState);
       const charging = statusText === ZappiStatusText.Charging || statusText === ZappiStatusText.Boosting; // true or false
       return charging;
+    });
+
+    const evConnectedCondition = this.homey.flow.getConditionCard('ev_is_connected');
+    evConnectedCondition.registerRunListener(async (args, state) => {
+      const dev: ZappiDevice = args.device;
+      if (!dev) {
+        this.error('Unable to detect device on flow: ev_is_connected');
+        return;
+      }
+      dev.log(`EV Is Connected: ${args} - ${state}`);
+      return dev.chargerStatus !== ZappiStatus.EvDisconnected;
+    });
+
+    const chargeModeCondition = this.homey.flow.getConditionCard('charge_mode_is');
+    chargeModeCondition.registerRunListener(async (args, state) => {
+      const dev: ZappiDevice = args.device;
+      if (!dev) {
+        this.error('Unable to detect device on flow: charge_mode_is');
+        return;
+      }
+      dev.log(`Charge Mode Is: ${args.charge_mode} - ${state}`);
+      return dev.chargeMode === dev.getChargeMode(args.charge_mode);
     });
 
     const startChargingAction = this.homey.flow.getActionCard('start_charging');


### PR DESCRIPTION
## Summary

Fixes #77 — the requested AND-conditions:

| Requested | Provided by |
|---|---|
| AND an EV is connected / disconnected | **New** "An EV is/isn't connected" condition (this PR) — also available via the built-in "Charging state is…" condition since #94 |
| AND charging started / stopped | Existing "Car is/isn't charging" condition (Homey inverts conditions natively) |
| AND charge mode is [dropdown] | **New** "Charge mode is/isn't [Fast/Eco/Eco+/Off]" condition (this PR) |

## Testing

- Publish-level validation passes; listeners follow the existing `is_charging` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)