### PR TITLE
Honor CT selection in Eddi total energy calculation

### DIFF
--- a/drivers/eddi/device.ts
+++ b/drivers/eddi/device.ts
@@ -200,12 +200,24 @@ export class EddiDevice extends Device {
       this._powerCalculationModeSetToAuto = false;
       const tmpSettings =
       {
-        includeCT1: true,
-        includeCT2: true,
-        includeCT3: true,
+        includeCT1: eddi.ectt1 === 'Internal Load',
+        includeCT2: eddi.ectt2 === 'Internal Load',
+        includeCT3: eddi.ectt3 === 'Internal Load',
       };
       this.setSettings(tmpSettings);
     }
+  }
+
+  /**
+   * Whether a CT should be included in the total energy calculation.
+   * Automatic mode includes CTs reported as "Internal Load"; manual mode
+   * follows the checkboxes in the advanced settings.
+   */
+  private includeCT(ctType: string, includeSetting?: boolean): boolean {
+    if (this._settings.powerCalculationMode === 'manual') {
+      return includeSetting === true;
+    }
+    return ctType === 'Internal Load';
   }
 
   /**
@@ -258,7 +270,15 @@ export class EddiDevice extends Device {
     this.setCapabilityValue('meter_power_ct2', meter_power_ct2_prev + meter_power_ct2).catch(this.error);
     this.setCapabilityValue('meter_power_ct3', meter_power_ct3_prev + meter_power_ct3).catch(this.error);
     this.setCapabilityValue('meter_power_generated', meter_power_gen_prev + meter_power_gen).catch(this.error);
-    this.setCapabilityValue('meter_power', meter_power_prev + ((meter_power_ct1 + meter_power_ct2 + meter_power_ct3) - meter_power_gen)).catch(this.error);
+
+    // Only CTs selected for the power calculation contribute to the total
+    // energy (the per-CT meters above always accumulate for reference).
+    const meter_power_total =
+      (this.includeCT(this._ct1Type, this._settings.includeCT1) ? meter_power_ct1 : 0)
+      + (this.includeCT(this._ct2Type, this._settings.includeCT2) ? meter_power_ct2 : 0)
+      + (this.includeCT(this._ct3Type, this._settings.includeCT3) ? meter_power_ct3 : 0)
+      - meter_power_gen;
+    this.setCapabilityValue('meter_power', meter_power_prev + meter_power_total).catch(this.error);
   }
 
   private validateCapabilities() {


### PR DESCRIPTION
## Summary

Fixes #83. The Eddi stored the `includeCT1–3` advanced settings but the energy calculation never read them: the total `meter_power` — which is what the Homey Energy tab consumes via `cumulativeCapability` — unconditionally summed all three CT meters. Excluding CT2/CT3 in manual mode therefore changed nothing, exactly as reported.

- The total now only accumulates energy from CTs that are selected: **automatic** mode includes CTs typed *Internal Load* (same semantics as the Zappi's power calculation), **manual** mode follows the checkboxes. Per-CT meters (`meter_power_ct1–3`) keep accumulating for reference.
- Also fixes an internal inconsistency: switching to automatic set the include flags to blanket `true` in one code path but type-derived in another; both now use the CT types.

## Behavior note

Automatic-mode users whose CTs are not typed *Internal Load* will see the total stop accumulating from those clamps — that is the intended meaning of automatic and matches the Zappi. Anyone wanting the old sum-everything behavior can select manual mode and tick all CTs.

## Testing

- Publish-level validation passes. Needs verification by the reporters (@daneroyd, @SmartHomeEnthusiast own Eddis; the author does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)