### PR TITLE
Zero stale Harvi power values instead of repeating the last report

### DIFF
--- a/drivers/harvi/device.ts
+++ b/drivers/harvi/device.ts
@@ -3,7 +3,7 @@ import { Harvi, MyEnergi } from 'myenergi-api';
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { MyEnergiApp } from '../../app';
 import { HarviSettings } from '../../models/HarviSettings';
-import { calculateEnergy } from '../../tools';
+import { calculateEnergy, isDataStale } from '../../tools';
 import { HarviDriver } from './driver';
 import { HarviData } from "./HarviData";
 
@@ -13,6 +13,7 @@ class HarviDevice extends Device {
   private _ectp1 = 0;
   private _ectp2 = 0;
   private _ectp3 = 0;
+  private _dataIsStale = false;
   private _ectt1 = '';
   private _ectt2 = '';
   private _ectt3 = '';
@@ -150,6 +151,25 @@ class HarviDevice extends Device {
   }
 
   private calculateValues(harvi: Harvi) {
+    // A Harvi is powered by the current in its CT clamps. When it measures
+    // solar panels only, it goes offline at night and the server keeps
+    // reporting its last (non-zero) values. Treat stale reports as zero,
+    // like the myenergi app does.
+    if (isDataStale(harvi.dat, harvi.tim)) {
+      if (!this._dataIsStale) {
+        this._dataIsStale = true;
+        this.log(`Harvi data is stale (last report ${harvi.dat} ${harvi.tim} UTC), reporting zero power.`);
+      }
+      this._ectp1 = 0;
+      this._ectp2 = 0;
+      this._ectp3 = 0;
+      this._power = 0;
+      return;
+    }
+    if (this._dataIsStale) {
+      this._dataIsStale = false;
+      this.log('Harvi data is fresh again.');
+    }
     this._ectp1 = harvi.ectp1;
     this._ectp2 = harvi.ectp2;
     this._ectp3 = harvi.ectp3;

--- a/tools.ts
+++ b/tools.ts
@@ -175,3 +175,27 @@ function getTime(): string {
 export function getFakeLibbiData(serialNumber = 99999996, mode: string | number = "BALANCE") {
     return { "sno": serialNumber, "dat": getDate(), "tim": getTime(), "soc": getRandomInt(100, 20), "sta": getRandomInt(6, 4), "lmo": mode, "gen": getRandomInt(4000), "grd": getRandomInt(2000), "frq": getRandom(51, 49), "vol": getRandomInt(2400, 2200), "che": 12.34, "pri": 1, "cmt": 254, "mbc": 10200, "mic": 5000, "pha": 1, "fwv": "3702S5.010", "ectt1": "Internal Load", "ectt2": "Grid", "ectt3": "None", "ectt4": "None", "ectt5": "None", "ectt6": "None", "newAppAvailable": false, "newBootloaderAvailable": false, "batteryDischargeEnabled": true };
 }
+
+/**
+ * Check whether a device's telemetry timestamp is stale. The myenergi
+ * server keeps returning the last received report when a device stops
+ * sending telemetry (e.g. a CT-powered Harvi on solar panels going dark
+ * at night), so old data must be detected by its timestamp.
+ * @param dat Date of data as reported by the API (dd-mm-yyyy, UTC)
+ * @param tim Time of data as reported by the API (hh:mm or hh:mm:ss, UTC)
+ * @param maxAgeMinutes Data older than this is considered stale
+ */
+export function isDataStale(dat?: string, tim?: string, maxAgeMinutes = 15): boolean {
+    if (!dat || !tim)
+        return false;
+    try {
+        const [day, month, year] = dat.split('-').map(Number);
+        const [hour, minute, second] = tim.split(':').map(Number);
+        if (!year || !month || !day)
+            return false;
+        const timestamp = Date.UTC(year, month - 1, day, hour || 0, minute || 0, second || 0);
+        return (Date.now() - timestamp) > maxAgeMinutes * 60 * 1000;
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #84. Root cause: the Harvi is **powered by the current in its own CT clamps** — a Harvi measuring only solar panels loses power at sunset and stops sending telemetry, but the myenergi server keeps returning its last received report. The app displayed that last daylight value (0–150 W) all night, corrupting Homey Energy accounting and Insights graphs. The official myenergi app avoids this by checking the report timestamp — the "watchdog" the reporter asked for.

- New `isDataStale(dat, tim)` helper compares the report's UTC timestamp against now.
- The Harvi device reports **zero power** (per-CT and total) when the report is older than 15 minutes, with a single log line on the stale/fresh transitions. Energy meters simply stop accumulating; recovery is automatic at sunrise.
- Zappi/Eddi are left as-is deliberately: they are mains powered, and zeroing a charger/heater during a temporary hub outage would be wrong more often than right.

## Testing

- Publish-level validation passes; helper behavior verified against the compiled output (fresh → false, old → true, missing fields → false).
- Real-world overnight verification needs a solar-only Harvi (@Tjita1 offered the exact setup in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)