### PR TITLE
fix: prevent crash when setSettings races a pending onSettings

### DIFF
--- a/drivers/eddi/device.ts
+++ b/drivers/eddi/device.ts
@@ -204,7 +204,13 @@ export class EddiDevice extends Device {
         includeCT2: eddi.ectt2 === 'Internal Load',
         includeCT3: eddi.ectt3 === 'Internal Load',
       };
-      this.setSettings(tmpSettings);
+      // setSettings throws while onSettings is still pending (the settings
+      // dialog that triggered auto mode awaits a cloud call), so retry on
+      // the next data update instead of crashing.
+      this.setSettings(tmpSettings).catch((error: unknown) => {
+        this._powerCalculationModeSetToAuto = true;
+        this.error(error);
+      });
     }
   }
 
@@ -423,7 +429,7 @@ export class EddiDevice extends Device {
 
     // Reset energy offset settings after one second to prevent potential conflicts.
     this._settingsTimeoutHandle = setTimeout(() => {
-      this.setSettings({ energyOffsetTotal: 0, energyOffsetCT1: 0, energyOffsetCT2: 0, energyOffsetCT3: 0, energyOffsetGenerated: 0 });
+      this.setSettings({ energyOffsetTotal: 0, energyOffsetCT1: 0, energyOffsetCT2: 0, energyOffsetCT3: 0, energyOffsetGenerated: 0 }).catch(this.error);
       clearTimeout(this._settingsTimeoutHandle);
     }, 1000);
   }

--- a/drivers/harvi/device.ts
+++ b/drivers/harvi/device.ts
@@ -203,7 +203,13 @@ class HarviDevice extends Device {
         includeCT2: true,
         includeCT3: true,
       };
-      this.setSettings(tmpSettings);
+      // setSettings throws while onSettings is still pending (the settings
+      // dialog that triggered auto mode awaits a cloud call), so retry on
+      // the next data update instead of crashing.
+      this.setSettings(tmpSettings).catch((error: unknown) => {
+        this._powerCalculationModeSetToAuto = true;
+        this.error(error);
+      });
     }
 
   }
@@ -309,7 +315,7 @@ class HarviDevice extends Device {
       this._settings.totalEnergyOffset = 0;
       // Reset the total energy offset after one second
       this._settingsTimeoutHandle = setTimeout(() => {
-        this.setSettings({ totalEnergyOffset: 0 });
+        this.setSettings({ totalEnergyOffset: 0 }).catch(this.error);
         clearTimeout(this._settingsTimeoutHandle);
       }, 1000);
     }

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -412,7 +412,13 @@ export class ZappiDevice extends Device {
         includeCT6: zappi.ectt6 === 'Internal Load',
       };
 
-      this.setSettings(tmpSettings);
+      // setSettings throws while onSettings is still pending (the settings
+      // dialog that triggered auto mode awaits a cloud call), so retry on
+      // the next data update instead of crashing.
+      this.setSettings(tmpSettings).catch((error: unknown) => {
+        this._powerCalculationModeSetToAuto = true;
+        this.error(error);
+      });
     }
 
     const evConnected = this._chargerStatus !== ZappiStatus.EvDisconnected;
@@ -980,7 +986,7 @@ export class ZappiDevice extends Device {
       this._settings.totalEnergyOffset = 0;
       // Reset the total energy offset after one second
       this._settingsTimeoutHandle = setTimeout(() => {
-        this.setSettings({ totalEnergyOffset: 0 });
+        this.setSettings({ totalEnergyOffset: 0 }).catch(this.error);
         clearTimeout(this._settingsTimeoutHandle);
       }, 1000);
     }


### PR DESCRIPTION
## Problem

Production crash report (v1.11.x, but the code path is unchanged in 2.0.0):

```
Error: Cannot set Settings while this.onSettings is still pending
    at ZappiDevice.setSettings (.../homey-apps-sdk-v3/lib/Device.js:422:13)
    at ZappiDevice.calculateValues (/app/drivers/zappi/device.js:332:18)
    at ZappiDevice.dataUpdated ...
```

**Race:** switching *Power calculation mode* to **automatic** makes `onSettings` `await` a cloud call (`getStatusZappi`), so it stays pending for up to several seconds. If a driver data poll lands in that window, `calculateValues` sees the `_powerCalculationModeSetToAuto` flag and calls `this.setSettings(tmpSettings)` — the SDK rejects because `onSettings` is still pending, and since the call was un-awaited and uncaught, the unhandled rejection killed the whole app.

The same pattern existed in the Eddi and Harvi drivers (Libbi is unaffected).

## Fix

- The deferred auto-CT `setSettings` in `calculateValues` (Zappi/Eddi/Harvi) now catches the rejection, logs it, and re-arms `_powerCalculationModeSetToAuto` so it simply retries on the next data update — by which time `onSettings` has resolved.
- The fire-and-forget energy-offset resets inside `setTimeout` callbacks get `.catch(this.error)` so they can never take the app down either.

No behavior change in the happy path; the automatic CT detection still lands, just one poll cycle later in the race case.

## Testing
- `tsc --noEmit` and ESLint clean.
- To reproduce manually: set a device's power calculation mode to automatic while data polling is active — previously a crash window, now retried gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)