### PR TITLE
fix: treat string "0" status from the myenergi API as success (implements #37)

### DIFF
--- a/drivers/eddi/device.ts
+++ b/drivers/eddi/device.ts
@@ -3,7 +3,7 @@ import { EddiBoost, EddiMode, EddiHeaterStatus, MyEnergi, Eddi } from 'myenergi-
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { MyEnergiApp } from '../../app';
 import { EddiSettings } from '../../models/EddiSettings';
-import { calculateEnergy } from '../../tools';
+import { calculateEnergy, isCommandSuccessful } from '../../tools';
 import { EddiDriver } from './driver';
 import { EddiData } from "./EddiData";
 
@@ -21,6 +21,8 @@ export class EddiDevice extends Device {
   private _ct1Power = 0;
   private _ct2Power = 0;
   private _ct3Power = 0;
+  private _heater1BaseName = 'Heater 1';
+  private _heater2BaseName = 'Heater 2';
   private _heater1Name = 'Heater 1';
   private _heater2Name = 'Heater 2';
   private _ct1Current = 0;
@@ -192,8 +194,10 @@ export class EddiDevice extends Device {
     this._ct1Type = eddi.ectt1;
     this._ct2Type = eddi.ectt2;
     this._ct3Type = eddi.ectt3;
-    this._heater1Name = (eddi.ht1 ? eddi.ht1 : this._heater1Name) + (eddi.hno === 1 ? ': ON' : ': OFF');
-    this._heater2Name = (eddi.ht2 ? eddi.ht2 : this._heater2Name) + (eddi.hno === 2 ? ': ON' : ': OFF');
+    if (eddi.ht1) this._heater1BaseName = eddi.ht1;
+    if (eddi.ht2) this._heater2BaseName = eddi.ht2;
+    this._heater1Name = this._heater1BaseName + (eddi.hno === 1 ? ': ON' : ': OFF');
+    this._heater2Name = this._heater2BaseName + (eddi.hno === 2 ? ': ON' : ': OFF');
     this._systemVoltage = eddi.vol ? (eddi.vol / 10) : 0;
     this._systemFrequency = eddi.frq;
     this._generatedPower = eddi.gen ? eddi.gen : 0;
@@ -343,7 +347,7 @@ export class EddiDevice extends Device {
   private async setEddiMode(isOn: boolean) {
     try {
       const result = await this.myenergiClient.setEddiMode(this.deviceId, isOn ? EddiMode.On : EddiMode.Off);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(result);
       }
       this.log(`Eddi was switched ${isOn ? 'on' : 'off'}`);
@@ -362,7 +366,7 @@ export class EddiDevice extends Device {
     const boost = heater === '2' ? EddiBoost.ManualHeater2 : EddiBoost.ManualHeater1;
     try {
       const result = await this.myenergiClient?.setEddiBoost(this.deviceId, boost, minutes);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(JSON.stringify(result));
       }
       this.log(`Eddi boost started on heater ${heater} for ${minutes} minutes`);
@@ -380,7 +384,7 @@ export class EddiDevice extends Device {
     const boost = heater === '2' ? EddiBoost.CancelHeater2 : EddiBoost.CancelHeater1;
     try {
       const result = await this.myenergiClient?.setEddiBoost(this.deviceId, boost);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(JSON.stringify(result));
       }
       this.log(`Eddi boost stopped on heater ${heater}`);

--- a/drivers/libbi/device.ts
+++ b/drivers/libbi/device.ts
@@ -1,6 +1,7 @@
 import { Device } from 'homey';
 import { Libbi, LibbiMode, MyEnergi } from 'myenergi-api';
 import { MyEnergiApp } from '../../app';
+import { isCommandSuccessful } from '../../tools';
 import { LibbiDriver } from './driver';
 import { LibbiData } from './LibbiData';
 import { LibbiModeText } from './LibbiModeText';
@@ -235,7 +236,7 @@ export class LibbiDevice extends Device {
     }
     try {
       const result = await this.myenergiClient?.setLibbiMode(this.deviceId, mode);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(JSON.stringify(result));
       }
       this._mode = modeText as LibbiModeText;

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -3,7 +3,7 @@ import { MyEnergi, Zappi, ZappiBoostMode, ZappiChargeMode, ZappiPhaseSetting, Za
 import { KeyValue } from 'myenergi-api/dist/src/models/KeyValue';
 import { MyEnergiApp } from '../../app';
 import { ZappiSettings } from '../../models/ZappiSettings';
-import { calculateEnergy } from '../../tools';
+import { calculateEnergy, isCommandSuccessful } from '../../tools';
 import { ZappiDriver } from './driver';
 import { ZappiBoostModeText } from './ZappiBoostModeText';
 import { ZappiChargeModeText } from './ZappiChargeModeText';
@@ -634,7 +634,7 @@ export class ZappiDevice extends Device {
   public async setChargerState(isOn: boolean): Promise<void> {
     try {
       const result = await this.myenergiClient?.setZappiChargeMode(this.deviceId, isOn ? this._lastOnState : ZappiChargeMode.Off);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(result);
       }
       this.triggerChargingFlow(isOn);
@@ -671,7 +671,7 @@ export class ZappiDevice extends Device {
     let serverReason = '';
     try {
       const result = await this.myenergiClient?.setZappiPhaseSetting(this.deviceId, phaseSetting);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         // Failed requests may carry the server's reason, e.g. "Only Zappi 2 supported"
         if (typeof result?.body === 'string' && result.body.length > 0) {
           serverReason = result.body;
@@ -729,7 +729,7 @@ export class ZappiDevice extends Device {
       this.setCapabilityValue('charge_mode_txt', `${this.getChargeModeText(chargeMode)}`).catch(this.error);
 
       const result = await this.myenergiClient?.setZappiChargeMode(this.deviceId, chargeMode);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(result);
       }
 
@@ -753,7 +753,7 @@ export class ZappiDevice extends Device {
       this.setCapabilityValue('zappi_boost_time', `${this.getBoostModeTime(completeTime ? completeTime : '0000')}`).catch(this.error);
 
       const result = await this.myenergiClient?.setZappiBoostMode(this.deviceId, boostMode, kWh, completeTime);
-      if (result.status !== 0) {
+      if (!isCommandSuccessful(result)) {
         throw new Error(JSON.stringify(result));
       }
 

--- a/services/MyEnergiFake.ts
+++ b/services/MyEnergiFake.ts
@@ -59,7 +59,8 @@ export class MyEnergiFake extends MyEnergi {
         return new Promise<any>((resolve) => {
             console.log(`MyEnergiFake->setZappiPhaseSetting(${serialNo}, ${phaseSetting})`);
             this._fakePhaseSetting = phaseSetting === ZappiPhaseSetting.SinglePhase ? '1' : (phaseSetting === ZappiPhaseSetting.ThreePhase ? '3' : 'auto');
-            resolve({ status: 0, statustext: "" });
+            // The real server returns the status as a string for this endpoint.
+            resolve({ status: "0", statustext: "" });
         });
     }
     public override getDayHourHistory(id: string, year: number, month: number, day: number, startHour?: number, noHours?: number): Promise<HistoryRecord[]> {

--- a/tools.ts
+++ b/tools.ts
@@ -177,6 +177,19 @@ export function getFakeLibbiData(serialNumber = 99999996, mode: string | number 
 }
 
 /**
+ * Check whether a myenergi control command succeeded. The server reports
+ * status 0 for success, but some endpoints (e.g. the Zappi phase setting)
+ * return it as the string "0" instead of a number, so compare numerically.
+ * @param result Response object from a myenergi cgi command
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isCommandSuccessful(result: any): boolean {
+    if (result === null || result === undefined || result.status === null || result.status === undefined || result.status === '')
+        return false;
+    return Number(result.status) === 0;
+}
+
+/**
  * Check whether a device's telemetry timestamp is stale. The myenergi
  * server keeps returning the last received report when a device stops
  * sending telemetry (e.g. a CT-powered Harvi on solar panels going dark


### PR DESCRIPTION
## The bug

Two diagnostics reports (from the #37 testers Marlark and tkroon89, both on v2.1.0) show every phase-setting change failing with:

```
Setting the Zappi phase setting to AUTO failed:
Error: {"status":"0","statustext":""}
```

Status `0` is the myenergi success code — but this endpoint returns it as the **string** `"0"`, and the code strict-compared it against the **number** `0`. Successful commands were therefore treated as failures: the user got an error toast, the picker reverted, and the capability value was never set. The command itself reached the Zappi just fine, which matches Marlark's "it doesn't stay on the setting" report exactly.

The response format is evidently endpoint-dependent (charge mode and Eddi boost returned numeric `0` in the same logs), so all status checks are hardened, not just the phase setting.

## Changes

- New `isCommandSuccessful()` helper in `tools.ts` that compares the status numerically and rejects missing/empty statuses.
- Replaced all eight strict `result.status !== 0` checks with the helper: Zappi charger state, phase setting, charge mode, boost mode; Eddi mode, start boost, stop boost; Libbi mode.
- `MyEnergiFake.setZappiPhaseSetting` now returns `{ status: "0" }` like the real server, so a local fake run exercises this regression (it was returning numeric `0`, which is why this never showed up locally).
- Eddi heater display names (`Tank 1: ON` etc.) now track the base name separately, so the `: ON`/`: OFF` suffix can no longer accumulate on polls where the hub omits `ht1`/`ht2`.

## Verification

- `npm run build`, ESLint, and `npx homey app validate --level publish` all pass.
- `isCommandSuccessful()` unit-checked against all response shapes: `{status:"0"}` and `{status:0}` → success; `{status:"-14"}`, `{status:-14}`, empty/missing status, `undefined`/`null` result → failure.
- Not yet run against the fake hub end-to-end — worth a quick local fake test (change the phase setting; on master it reproduces the reported error, with this fix it should succeed).

Implements #37 — keep open until Marlark/tkroon89 confirm on real 3-phase hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)