### PR TITLE
fix: Eddi heater ON/OFF label reflects actual heating, not selected heater (implements #104)

### DIFF
--- a/drivers/eddi/device.ts
+++ b/drivers/eddi/device.ts
@@ -196,8 +196,11 @@ export class EddiDevice extends Device {
     this._ct3Type = eddi.ectt3;
     if (eddi.ht1) this._heater1BaseName = eddi.ht1;
     if (eddi.ht2) this._heater2BaseName = eddi.ht2;
-    this._heater1Name = this._heater1BaseName + (eddi.hno === 1 ? ': ON' : ': OFF');
-    this._heater2Name = this._heater2BaseName + (eddi.hno === 2 ? ': ON' : ': OFF');
+    // hno is only the *selected* heater; it is actually heating only while
+    // the Eddi is diverting or boosting.
+    const heating = eddi.sta === EddiHeaterStatus.Diverting || eddi.sta === EddiHeaterStatus.Boost;
+    this._heater1Name = this._heater1BaseName + (heating && eddi.hno === 1 ? ': ON' : ': OFF');
+    this._heater2Name = this._heater2BaseName + (heating && eddi.hno === 2 ? ': ON' : ': OFF');
     this._systemVoltage = eddi.vol ? (eddi.vol / 10) : 0;
     this._systemFrequency = eddi.frq;
     this._generatedPower = eddi.gen ? eddi.gen : 0;


### PR DESCRIPTION
## The bug

daneroyd noticed in #104 that Homey showed **Tank 1: ON** while the myenergi app showed the tank as off. The label derived ON/OFF from `eddi.hno` alone — but `hno` is just the **currently selected** heater number. An idle Eddi still has a heater selected, so the label read "ON" permanently (which is also why its timestamp never refreshed in his screenshot: the value literally never changed).

## Change

A heater is now labeled ON only when it is the selected heater **and** the Eddi status (`sta`) is Diverting (3) or Boost (4) — i.e. it is actually heating. In Starting/Paused/DSR/Hot/Stopped states both heaters read OFF, matching what the myenergi app shows. Side effect: the labels now flip when a boost or diversion starts/stops, so their "last updated" timestamps refresh meaningfully.

## Verification

- `npm run build`, ESLint, and `npx homey app validate --level publish` all pass.
- Not exercised against live hardware — daneroyd's Eddi is the verification target (idle Eddi should show both tanks OFF; starting a boost on tank 1 should flip it to ON).

Implements #104 — reopen/keep open until daneroyd confirms on his Eddi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)