### PR TITLE
fix: selecting Off in the charge mode picker now stops the charger (implements #37)

### DIFF
--- a/.claude/skills/homey-app-dev/SKILL.md
+++ b/.claude/skills/homey-app-dev/SKILL.md
@@ -55,6 +55,7 @@ Translations: this app maintains en, no, nl, sv, de. Every new user-visible stri
 - Enum capability values are string IDs; adding new enum values to an existing capability is backward compatible, removing/renaming breaks users' flows.
 - `energy` objects (per driver or device class `evcharger`, cumulative, etc.) power the Homey Energy tab — see `the-basics/devices/energy.md`.
 - Device class changes (e.g. to `evcharger`) need a `setClass` migration in `onInit`.
+- **Energy tab visuals are Homey's, not the app's (verified empirically July 2026):** apps only publish `evcharger_charging_state` (`plugged_out`/`plugged_in`/`plugged_in_charging`/`plugged_in_paused`); the garage/door/car scene does not react to it (door stays open with a car shown even while the charger reports `plugged_out`). Requests to animate it are Athom feature requests, not app issues.
 - **Multiple picker capabilities (undocumented, verified empirically July 2026 on the iOS app):** the device view shows ONE picker widget with a dropdown menu to switch between picker capabilities. The menu lists them in capability order, but the DEFAULT selection is the LAST picker capability in the device's capability order — so put the picker you want as default last among the pickers. Not sticky: the app recomputes the default every time the device view opens. Order changes on existing devices require a capability rebuild (remove+re-add all in the new order) in `onInit`, since set-based change detection won't fire.
 
 ## CLI (npx homey ...)

--- a/drivers/zappi/device.ts
+++ b/drivers/zappi/device.ts
@@ -769,9 +769,13 @@ export class ZappiDevice extends Device {
    * @param value Charge mode
    * @param opts Options
    */
-  private async onCapabilityChargeMode(value: ZappiChargeMode, opts: unknown): Promise<void> {
+  private async onCapabilityChargeMode(value: ZappiChargeMode | string, opts: unknown): Promise<void> {
     this.log(`Charge Mode: ${value} - ${opts}`);
-    this._chargeMode = value;
+    // Homey delivers enum capability values as strings ('1'..'4'), so
+    // normalize before comparing with the numeric ZappiChargeMode values.
+    // Comparing the raw string made Off ('4' !== 4) behave as "on", which
+    // re-sent the last active mode instead of stopping the charger.
+    this._chargeMode = Number(value) as ZappiChargeMode;
     if (this._chargeMode !== ZappiChargeMode.Off) {
       this._lastOnState = this._chargeMode;
     }


### PR DESCRIPTION
## The bug

Marlark reported on #37 that merely opening the phase-settings picker switched his stopped Zappi to Eco+. His July 6 diagnostics log shows the mechanism directly:

```
Charge Mode: 4 - [object Object]
Zappi was switched on
```

Homey delivers enum capability values as **strings** (`'1'`–`'4'`), but `onCapabilityChargeMode` compared them against the **numeric** `ZappiChargeMode` enum. `'4' !== 4`, so **Off was always treated as "on"**, and `setChargerState(true)` re-sent the last active mode (his: Eco+) instead of stopping the charger. Two user-visible symptoms:

- Selecting **Off** in the charge mode selector never actually stopped charging — it re-sent the last active mode.
- The iOS app commits the picker's current value when switching the picker menu (e.g. to phase settings); on a stopped Zappi that commit fired the listener with `'4'` and the bug turned it into "switch on with Eco+".

## Change

Normalize the incoming value with `Number(value)` at the top of the listener before any enum comparison — third member of the string-vs-number family after the phase-setting status (#107). Flow cards are unaffected (they use text IDs through `getChargeMode()`), and the Libbi selector was checked clean (string IDs against a string enum).

Once normalized, the picker's commit-on-menu-switch becomes harmless: it re-sends the mode the Zappi is already in.

## Verification

- `npm run build`, ESLint, and `npx homey app validate --level publish` all pass.
- Verification targets on hardware: (1) with the Zappi stopped, open the picker menu and switch to phase settings — mode must stay Off; (2) select Off in the charge mode selector while charging — charging must actually stop. Marlark is set up to verify both.

Also includes a one-line docs commit recording that the Energy tab garage visuals ignore `evcharger_charging_state` (verified July 2026, asked in #104).

Implements #37 — keep open until Marlark confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)